### PR TITLE
Implemented `Screen` option separately from `Resolution` and improved menu code question mark. Also splash screen skip strat, some refactoring.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -164,7 +164,7 @@ function SaveConfig()
 	for key, param in pairs(Config) do
 		str = str..key.."="..param.."\n"
 	end
-	success, message = love.filesystem.write("keys.conf", str:sub(1,-2))
+	local success, message = love.filesystem.write("keys.conf", str:sub(1,-2))
 	ConfigBroke = false
 end
 

--- a/engine.lua
+++ b/engine.lua
@@ -17,17 +17,17 @@
 ]==]
 
 Board = {
-	lock_delay = 2,
-	maxrots = 99,--15,
-    gravity = 1,
-    AS_delay = 0.25, --15f@60fps
-	AS_repeat = 1/60, --1f@60fps
+	lock_delay  = 2,
+	maxrots     = 99,--15,
+    gravity     = 1,
+    AS_delay    = 0.25, --15f@60fps
+	AS_repeat   = 1/60, --1f@60fps
 	spawn_delay = 0.5,
 	--startbag = {"I", "T", "L", "J", "O"}, -- 7-bag with no SZ
 	-- startbag = {"I", "T", "L", "J", "O", "S", "Z"}, -- re-introduction of SZ in starting bag after 2-history addition
-	mainbag = {'I', 'I', 'L', 'L', 'J', 'J', 'S', 'S', 'Z', 'Z', 'T', 'T', 'O', 'O'}, -- changed again to 14-bag strict 3-history
+	--mainbag      = {'I', 'I', 'L', 'L', 'J', 'J', 'S', 'S', 'Z', 'Z', 'T', 'T', 'O', 'O'}, -- changed again to 14-bag strict 3-history
     starthistory = {'S', 'Z', 'O'},                                                   -- with no starting bag since history starts at SZO
-	-- mainbag = {'test'},
+    mainbag = {'test'},
 	-- mainbag = {'I'},
 	-- mainbag = {'I', 'L', 'J', 'S', 'Z', 'T', 'O', 'F5l', 'F5r', 'I5', 'L5l', 'L5r', 'N5l', 'N5r', 'P5l', 'P5r', 'T5', 'U5', 'V5', 'W5', 'X5', 'Y5l', 'Y5r', 'Z5l', 'Z5r' },
 	-- mainbag = {'I', 'L', 'J', 'S', 'Z', 'T', 'O', 'F5l', 'F5r', 'I5', 'L5l', 'L5r', 'N5l', 'N5r', 'P5l', 'P5r', 'T5', 'U5', 'V5', 'W5', 'X5', 'Y5l', 'Y5r', 'Z5l', 'Z5r', 'w6' },
@@ -208,10 +208,10 @@ Board = {
 				love.graphics.draw(text, xoff, yoff, 0, 1, 1, text:getWidth()/2, text:getHeight()/2)
 			end)
 			--]]
-			board:add_event("update", "before", function(board)
-				if board.animation_time <= 0 then
-					board:drop_lines()
-					board.spawn_timer = board.spawn_delay - board.spawn_delay_after_line
+			board:add_event("update", "before", function(self)
+				if self.animation_time <= 0 then
+					self:drop_lines()
+					self.spawn_timer = self.spawn_delay - self.spawn_delay_after_line
 					PlaySFX("classic_lock")
 					return true
 				end
@@ -600,7 +600,7 @@ Board = {
 			-- [[
             local fieldbytes = {s:byte(5,-1)}
             local x, y = 1, 1
-            for n, b in ipairs(fieldbytes) do
+            for _, b in ipairs(fieldbytes) do
                 b = b - 0x80
                 for i = 0,4 do
                     if b%2 == 1 then board.grid[x+4-i][y] = true; b = b-1 end
@@ -792,7 +792,7 @@ Board = {
 		end
 		
 		
-		for n, trail in ipairs(board.trails) do
+		for _, trail in ipairs(board.trails) do
 			love.graphics.setColor(unpack(trail.c))
 			local x, y, h = trail.x, trail.y, trail.h
 			board.trail_mesh:setVertex(3, 0, (0.5-h)*sc, 0,0, 1,1,1,0)
@@ -813,14 +813,14 @@ Board = {
 		local pc = board.piece
 		if pc then
 			love.graphics.setColor(pc.colour)
-			for _, b in ipairs(pc.blocks[pc.orientation]) do
+			for _, bl in ipairs(pc.blocks[pc.orientation]) do
                 if not board.last_rotate_point then
-                    local x, y = b[1] + pc.x, b[2] + pc.y
+                    local x, y = bl[1] + pc.x, bl[2] + pc.y
                     if not board.current_grounded then y = y - board.gravity_acc end
                     -- love.graphics.rectangle("fill", (x-6)*sc, (10-y)*sc, sc, sc)
                     board:putTheBlock(x, y)
                 else
-                    local x1, y1 = unpack(b)
+                    local x1, y1 = unpack(bl)
                     local rotate_anim_time = 0.1
                     local t = math.min((board.time - board.last_rotate_time)/rotate_anim_time, 1)-1
                     local a = t*board.last_rotate_dir*math.pi/2
@@ -836,18 +836,18 @@ Board = {
 		
 		local gh = board.ghost
 		if gh and board.animation_time <= 0 and not board.dead then
-			local r, g, b, a = unpack(gh.colour)
-			local t = board.spawn_timer/board.spawn_delay
+			local gh_r, gh_g, gh_b, a = unpack(gh.colour)
+			local t                   = board.spawn_timer/board.spawn_delay
 			love.graphics.setLineWidth(sc/8)
 			for _, bl in ipairs(gh.blocks[gh.orientation]) do
 				local x, y = bl[1] + gh.x, bl[2] + gh.y
 				if t == 0 then
-					love.graphics.setColor(r,g,b,a)
+					love.graphics.setColor(gh_r, gh_g, gh_b, a)
 					love.graphics.rectangle("line", (x-5.9375)*sc, (10.0625-y)*sc, sc*0.875, sc*0.875)
 					love.graphics.line((x-5.9375)*sc, (10.0625-y)*sc, (x-5.0625)*sc, (10.9375-y)*sc)
 				else
-					love.graphics.setColor(1,1,1,t <= 0.1 and a or 0)
-					love.graphics.rectangle("fill", (x-6)*sc, (10-y )*sc, sc, sc)
+					love.graphics.setColor(1, 1, 1, t <= 0.1 and a or 0)
+					love.graphics.rectangle("fill", (x-6)*sc, (10-y)*sc, sc, sc)
 				end
 			end
 		end
@@ -870,17 +870,17 @@ Board = {
         board:do_draw_items("back")
 		
 		love.graphics.setColor(0.5,0.5,0.5)
-		local n = 1
-		local i = board.animate[n]
-		while i do
-			local startt, endt = i.startt, i.endt
+		local anim_index = 1
+		local anim_item  = board.animate[anim_index]
+		while anim_item do
+			local startt, endt = anim_item.startt, anim_item.endt
 			if board.time > endt then
-				table.remove(board.animate, n)
+				table.remove(board.animate, anim_index)
 			else
-				love.graphics.draw(i.object, Interpolate(i.func, board.time, startt, endt))
-				n = n+1
+				love.graphics.draw(anim_item.object, Interpolate(anim_item.func, board.time, startt, endt))
+				anim_index = anim_index +1
 			end
-			i = board.animate[n]
+			anim_item = board.animate[anim_index]
 		end
 		
 		love.graphics.setColor(1,1,1,1)
@@ -891,8 +891,8 @@ Board = {
 		for n = 1, #board.nexts do
 			local piece = board.nexts[n]
 			love.graphics.setColor(unpack(piece.colour))
-			for _, b in ipairs(piece.blocks[piece.orientation]) do
-				local x, y = b[1], b[2]
+			for _, bl in ipairs(piece.blocks[piece.orientation]) do
+				local x, y = bl[1], bl[2]
 				-- love.graphics.rectangle("fill", (x+8)*sc, (4*n-y-12)*sc, sc, sc)
 				board:putTheBlock(x+14, y+21-3.5*(n-1))
 			end
@@ -900,11 +900,11 @@ Board = {
 		
 		local hold = board.hold_piece
 		if hold then
-			local r, g, b, a = unpack(hold.colour)
-			if board.held then r, g, b, a = r/4+0.25, g/4+0.25, b/4+0.25, a end
-			love.graphics.setColor(r, g, b, a)
-			for _, b in ipairs(hold.blocks[hold.orientation]) do
-				local x, y = b[1], b[2]
+			local h_r, h_g, h_b, a = unpack(hold.colour)
+			if board.held then h_r, h_g, h_b, a = h_r /4+0.25, h_g /4+0.25, h_b /4+0.25, a end
+			love.graphics.setColor(h_r, h_g, h_b, a)
+			for _, bl in ipairs(hold.blocks[hold.orientation]) do
+				local x, y = bl[1], bl[2]
 				-- love.graphics.rectangle("fill", (x-10)*sc, (-y-9)*sc, sc, sc)
 				board:putTheBlock(x-4, y+21)
 			end
@@ -929,67 +929,67 @@ Board = {
 	
 	reset = function(board, seed, level, character)
 		board.first_frame = true
-		board.cur_lock = 0
-		board.lock_delay = Board.lock_delay
-		board.cur_rots = 0
-		board.max_y = 0
-		board.pieces = 0
-		board.lines = 0
-        board.all_clears = 0
-		board.score = 0
-		board.last_score = 0
+		board.cur_lock    = 0
+		board.lock_delay  = Board.lock_delay
+		board.cur_rots    = 0
+		board.max_y       = 0
+		board.pieces      = 0
+		board.lines       = 0
+        board.all_clears  = 0
+		board.score       = 0
+		board.last_score  = 0
 		board.drop_points = 0
-		board.recent_actions = {}
-        board.percentile = 0
-        board.level = level or board.startlevel
-        board.startlevel = level or board.startlevel
-		board.last_level = 0
-		board.level_time = -2
-        board.time = -2
-		board.gravity = Board.gravity
+        board.percentile  = 0
+        board.level       = level or board.startlevel
+        board.startlevel  = level or board.startlevel
+		board.last_level  = 0
+		board.level_time  = -2
+        board.time        = -2
+		board.gravity     = Board.gravity
         board.gravity_acc = 0
-        board.AS_acc = 0
-        board.AS_dir = 0
-        board.AS_timer = 0
-		board.AS_repeat = Board.AS_repeat
-		board.AS_delay = Board.AS_delay
+        board.AS_acc      = 0
+        board.AS_dir      = 0
+        board.AS_timer    = 0
+		board.AS_repeat   = Board.AS_repeat
+		board.AS_delay    = Board.AS_delay
 		board.spawn_timer = 0
 		board.spawn_delay = Board.spawn_delay
-		board.held = false
-		board.spin = false
-		board.dead = false
-		board.hold_piece = nil
-		board.character = character
+		board.held        = false
+		board.spin        = false
+		board.dead        = false
+		board.hold_piece  = nil
+		board.character   = character
         board.edge_colour = character and Characters[character].colour or board.speedcurve.colour
-        board.animation_time = 0
-        board.scale_x = 1
-        board.scale_y = 1
+        board.scale_x     = 1
+        board.scale_y     = 1
 		-- board.ignore_next_event = false
-		board.trails = {}
-		board.last_clear = 0
-		board.last_spin = false
-		board.last_id = nil
-        board.last_lines = {}
-		board.prev = {}
-		board.stat = {[false] = {}, [true] = {}}
-		board.grid = {{},{},{},{},{},{},{},{},{},{}}
+		board.trails      = {}
+		board.last_clear  = 0
+		board.last_spin   = false
+		board.last_id     = nil
+        board.last_lines  = {}
+		board.prev        = {}
+		board.stat        = {[false] = {}, [true] = {}}
+		board.grid        = {{},{},{},{},{},{},{},{},{},{}}
 		-- board.bag = Deepcopy(Board.startbag)
-		board.bag = Deepcopy(Board.mainbag)
-		board.history = Deepcopy(Board.starthistory)
-		board.rep_queue = {}
-		board.animate = {}
-		board.events = {}
-        board.draw_items = {back = {}, front = {}, overlay = {}}
+		board.bag         = Deepcopy(Board.mainbag)
+		board.history     = Deepcopy(Board.starthistory)
+		board.rep_queue   = {}
+		board.animate     = {}
+		board.events      = {}
+        board.draw_items  = {back = {}, front = {}, overlay = {}}
+        board.recent_actions = {}
+        board.animation_time = 0
         -- board.anim_sprites = {}
-        board.current_grounded = false
+        board.current_grounded     = false
 		board.last_collision_down  = nil
 		board.last_collision_left  = nil
 		board.last_collision_right = nil
 		board.last_collision_cw    = nil
 		board.last_collision_ccw   = nil
-        board.last_rotate_point = nil
-        board.last_rotate_time  = nil
-        board.last_rotate_dir   = 0
+        board.last_rotate_point    = nil
+        board.last_rotate_time     = nil
+        board.last_rotate_dir      = 0
 		
 		board.random:setSeed(seed)
 		-- board:shuffle_bag()
@@ -1005,8 +1005,8 @@ Board = {
 				board.stat[false][id][n] = 0
 			end
 		end
-		for k, v in pairs(Board.events) do
-			board.events[v] = {}
+		for _, v in pairs(Board.events) do
+			board.events[v]          = {}
 			board.events[v].before   = {}
 			board.events[v].after    = {}
 			board.events[v].override = {}
@@ -1021,16 +1021,15 @@ Board = {
 
 	saveScore = function(board)
 		local isClear = (board.speedcurve[board.level].level_name == math.huge and board.level ~= board.startlevel)
-		print("score = " .. board.score .. ", clearscore = " .. (board.level_final_score or "nil"))
 		table.insert(HighScores[board.speedcurve.name],
 			{
 				score 		= board.score,
-				clearScore	= isClear and (board.level_final_score or 0),
+				clear_score	= isClear and (board.level_final_score or 0),
 				lines		= board.lines,
-				startLevel	= board.startlevel,
-				finalLevel	= board.level or board.startlevel,
+				start_level	= board.startlevel,
+				final_level	= board.level or board.startlevel,
 				time		= board.time,
-				clearTime   = isClear and board.level_time
+				clear_time  = isClear and board.level_time
 			}
 		)
 		SaveHighScores()
@@ -1038,16 +1037,16 @@ Board = {
 	
 	new = function(curve, seed, blocksize, posx, posy)
 		local newboard = {
-			nexts = {},
-			next_count = curve.prev,
-            allow_hold = curve.hold,
-            level_type = curve.LV,
-            speedcurve = curve,
-			size = blocksize,
-            position_x = posx,
-            position_y = posy,
+			nexts       = {},
+			next_count  = curve.prev,
+            allow_hold  = curve.hold,
+            level_type  = curve.LV,
+            speedcurve  = curve,
+			size        = blocksize,
+            position_x  = posx,
+            position_y  = posy,
             edge_colour = curve.colour,
-			block_mesh = love.graphics.newMesh({
+			block_mesh  = love.graphics.newMesh({
 				{-0.5, -0.5, 0, 0, 1.0,1.0,1.0, 1},
 				{ 0.5, -0.5, 1, 0, 0.9,0.9,0.9, 1},
 				{ 0.5,  0.5, 1, 1, 0.7,0.7,0.7, 1},
@@ -1058,43 +1057,43 @@ Board = {
 				{ 0.5,  0.5, 0, 0, 1,1,1,1},
 				{ 0,    0,   0, 0, 1,1,1,0},
 			}, "fan", "dynamic"),
-			random = love.math.newRandomGenerator(seed),
-			canvas = love.graphics.newCanvas(),
-			field_canvas = love.graphics.newCanvas(),
-			glow_canvas = love.graphics.newCanvas(),
+			random         = love.math.newRandomGenerator(seed),
+			canvas         = love.graphics.newCanvas(),
+			field_canvas   = love.graphics.newCanvas(),
+			glow_canvas    = love.graphics.newCanvas(),
 			overlay_canvas = love.graphics.newCanvas(),
-			getScore = Board.getScore,
-			check_cell = Board.check_cell,
+			getScore       = Board.getScore,
+			check_cell     = Board.check_cell,
 			check_collision_with = Board.check_collision_with,
-			rotate_cw = Board.rotate_cw,
-			rotate_ccw = Board.rotate_ccw,
+			rotate_cw      = Board.rotate_cw,
+			rotate_ccw     = Board.rotate_ccw,
 			initial_rotate = Board.initial_rotate,
-			check_spin = Board.check_spin,
-			update_ghost = Board.update_ghost,
-			create_ghost = Board.create_ghost,
-			add_trails = Board.add_trails,
-			place_raw = Board.place_raw,
-			place = Board.place,
-			clear_lines = Board.clear_lines,
-            drop_lines = Board.drop_lines,
-            is_grid_empty = Board.is_grid_empty,
-			shuffle_bag = Board.shuffle_bag,
-			pull_next = Board.pull_next,
-			get_piece = Board.get_piece,
-			update = Board.update,
-			draw = Board.draw,
-			reset = Board.reset,
-			hold = Board.hold,
-            setLV = Board.setLV,
-            encodeBoard = Board.encodeBoard,
-            decodeBoard = Board.decodeBoard,
-			add_event = Board.add_event,
-			call_events = Board.call_events,
-			add_draw_item = Board.add_draw_item,
-			do_draw_items = Board.do_draw_items,
-            darken_glow = Board.darken_glow,
-            putTheBlock = Board.putTheBlock,
-			saveScore = Board.saveScore
+			check_spin     = Board.check_spin,
+			update_ghost   = Board.update_ghost,
+			create_ghost   = Board.create_ghost,
+			add_trails     = Board.add_trails,
+			place_raw      = Board.place_raw,
+			place          = Board.place,
+			clear_lines    = Board.clear_lines,
+            drop_lines     = Board.drop_lines,
+            is_grid_empty  = Board.is_grid_empty,
+			shuffle_bag    = Board.shuffle_bag,
+			pull_next      = Board.pull_next,
+			get_piece      = Board.get_piece,
+			update         = Board.update,
+			draw           = Board.draw,
+			reset          = Board.reset,
+			hold           = Board.hold,
+            setLV          = Board.setLV,
+            encodeBoard    = Board.encodeBoard,
+            decodeBoard    = Board.decodeBoard,
+			add_event      = Board.add_event,
+			call_events    = Board.call_events,
+			add_draw_item  = Board.add_draw_item,
+			do_draw_items  = Board.do_draw_items,
+            darken_glow    = Board.darken_glow,
+            putTheBlock    = Board.putTheBlock,
+			saveScore      = Board.saveScore
 		}
 		newboard.block_mesh:setTexture(blocktexture)
 		for i = 1, curve.prev do newboard.nexts[i] = 0 end

--- a/engine.lua
+++ b/engine.lua
@@ -1024,13 +1024,13 @@ Board = {
 		print("score = " .. board.score .. ", clearscore = " .. (board.level_final_score or "nil"))
 		table.insert(HighScores[board.speedcurve.name],
 			{
-				score=board.score,
-				clearScore=isClear and (board.level_final_score or 0),
-				lines=board.lines,
-				startLevel=board.startlevel,
-				finalLevel=(board.level or board.startlevel),
-				time=board.time,
-				clearTime=isClear and board.level_time
+				score 		= board.score,
+				clearScore	= isClear and (board.level_final_score or 0),
+				lines		= board.lines,
+				startLevel	= board.startlevel,
+				finalLevel	= board.level or board.startlevel,
+				time		= board.time,
+				clearTime   = isClear and board.level_time
 			}
 		)
 		SaveHighScores()

--- a/highscores.lua
+++ b/highscores.lua
@@ -1,5 +1,5 @@
 --[[
-    What the fuck am I doing here? I'm not like the rest of the comments, I swear!
+    What the fuck am I doing here? I'm not like the rest of the comments, I swear! -MarkGamed7794 2021
 ]]
 
 HighScores = {}
@@ -7,25 +7,24 @@ HighScores = {}
 function LoadHighScores()
     HighScores = {}
     local scoremachinebroke = false
-    if(love.filesystem.getInfo("highscores.sav")) then
+    if love.filesystem.getInfo("highscores.sav") then
         local currentMode = ""
         for line in love.filesystem.lines("highscores.sav") do
             local header = line:match("%[(.+)%]")
-            if(header) then
+            if header then
                 currentMode = header
                 HighScores[currentMode] = {}
             else
-                score, clearScore, lines, startlevel, stoplevel, time, clearTime = line:match("(.+),(.+),(.+),(.+),(.+),(.+),(.+)")
-                if(startlevel and score and lines and stoplevel)  then
-                    --print("Loaded an entry for mode "..currentMode..": "..startlevel..","..score..","..lines..","..stoplevel..","..clearScore..","..time..","..clearTime)
+                local score, clearScore, lines, startlevel, stoplevel, time, clearTime = line:match("(.+),(.+),(.+),(.+),(.+),(.+),(.+)")
+                if startlevel and score and lines and stoplevel then
                     table.insert(HighScores[currentMode],{
-                        ["startLevel"]=tonumber(startlevel),
-                        ["score"]=score,
-                        ["lines"]=lines,
-                        ["finalLevel"]=tonumber(stoplevel),
-                        ["clearScore"]=clearScore ~= "none" and clearScore,
-                        ["time"]=tonumber(time),
-                        ["clearTime"]=clearTime ~= "none" and tonumber(clearTime)
+                        ["startLevel"] = tonumber(startlevel),
+                        ["score"]      = score,
+                        ["lines"]      = lines,
+                        ["finalLevel"] = tonumber(stoplevel),
+                        ["clearScore"] = clearScore ~= "none" and clearScore,
+                        ["time"]       = tonumber(time),
+                        ["clearTime"]  = clearTime ~= "none" and tonumber(clearTime)
                     })
                 elseif #line > 0 then
                     scoremachinebroke = true
@@ -33,39 +32,30 @@ function LoadHighScores()
             end
 		end
     else scoremachinebroke = true end
-    if(scoremachinebroke) then
-        print("Nevermind, it's fucked up, resetting high scores to default!")
+    if scoremachinebroke then
+        print("Nevermind, it broke, resetting high scores to default!")
         -- make some default high scores
-        for _,mode in pairs(Levels) do
-            local name = mode.name
-            HighScores[name] = {}
+        for _, mode in pairs(Levels) do
+            HighScores[mode.name] = {}
         end
         SaveHighScores()
     end
-    --[[
-    if(Title) then
-        local hs_keys = {}
-        for k,v in pairs(HighScores) do table.insert(hs_keys,k) end
-        table.sort(hs_keys) -- alphabetical order
-        Title.highscores.modeList = hs_keys
-    end
-    --]]
 end
 
 function SaveHighScores()
     local str = ""
-    for mode,scores in pairs(HighScores) do
+    for mode, scores in pairs(HighScores) do
         --first things first, we have to sort them by score, of course!
-        table.sort(HighScores[mode],function(a,b) return tonumber(a.score) > tonumber(b.score) end)
+        table.sort(HighScores[mode], function(a, b) return tonumber(a.score) > tonumber(b.score) end)
         local modeStr = "["..mode.."]\n"
-        for i=1,#HighScores[mode] do
+        for i=1, #HighScores[mode] do
             local score = HighScores[mode][i]
             local scoreStr = score.score .. "," ..
                              (score.clearScore or "none") .. "," ..
                              score.lines .. "," ..
                              score.startLevel .. "," ..
                              score.finalLevel .. "," ..
-                             score.time .. "," .. 
+                             score.time .. "," ..
                              (score.clearTime or "none")
                              
                              
@@ -73,8 +63,7 @@ function SaveHighScores()
         end
         str = str .. modeStr .."\n"
     end
-    --print(str)
-    success, message = love.filesystem.write("highscores.sav", str:sub(1,-2))
+    local success, message = love.filesystem.write("highscores.sav", str:sub(1,-2))
 end
 
 LoadHighScores()

--- a/highscores.lua
+++ b/highscores.lua
@@ -1,38 +1,37 @@
---[[
-    What the fuck am I doing here? I'm not like the rest of the comments, I swear! -MarkGamed7794 2021
-]]
-
 HighScores = {}
 
 function LoadHighScores()
     HighScores = {}
-    local scoremachinebroke = false
+    local no_scores_file = false
     if love.filesystem.getInfo("highscores.sav") then
-        local currentMode = ""
+        local current_mode = ""
         for line in love.filesystem.lines("highscores.sav") do
             local header = line:match("%[(.+)%]")
             if header then
-                currentMode = header
-                HighScores[currentMode] = {}
+                current_mode             = header
+                HighScores[current_mode] = {}
             else
-                local score, clearScore, lines, startlevel, stoplevel, time, clearTime = line:match("(.+),(.+),(.+),(.+),(.+),(.+),(.+)")
-                if startlevel and score and lines and stoplevel then
-                    table.insert(HighScores[currentMode],{
-                        ["startLevel"] = tonumber(startlevel),
+                local score, clear_score, lines, start_level, stop_level, time, clear_time = line:match("(.+),(.+),(.+),(.+),(.+),(.+),(.+)")
+                if start_level and score and lines and stop_level then
+                    table.insert(HighScores[current_mode],{
+                        ["start_level"] = tonumber(start_level),
                         ["score"]      = score,
                         ["lines"]      = lines,
-                        ["finalLevel"] = tonumber(stoplevel),
-                        ["clearScore"] = clearScore ~= "none" and clearScore,
+                        ["final_level"] = tonumber(stop_level),
+                        ["clear_score"] = clear_score ~= "none" and clear_score,
                         ["time"]       = tonumber(time),
-                        ["clearTime"]  = clearTime ~= "none" and tonumber(clearTime)
+                        ["clear_time"]  = clear_time ~= "none" and tonumber(clear_time)
                     })
                 elseif #line > 0 then
-                    scoremachinebroke = true
+                    no_scores_file = true
                 end
             end
 		end
-    else scoremachinebroke = true end
-    if scoremachinebroke then
+    else
+        no_scores_file = true
+    end
+
+    if no_scores_file then
         print("Nevermind, it broke, resetting high scores to default!")
         -- make some default high scores
         for _, mode in pairs(Levels) do
@@ -44,24 +43,20 @@ end
 
 function SaveHighScores()
     local str = ""
-    for mode, scores in pairs(HighScores) do
+    for mode_id, _ in pairs(HighScores) do
         --first things first, we have to sort them by score, of course!
-        table.sort(HighScores[mode], function(a, b) return tonumber(a.score) > tonumber(b.score) end)
-        local modeStr = "["..mode.."]\n"
-        for i=1, #HighScores[mode] do
-            local score = HighScores[mode][i]
-            local scoreStr = score.score .. "," ..
-                             (score.clearScore or "none") .. "," ..
-                             score.lines .. "," ..
-                             score.startLevel .. "," ..
-                             score.finalLevel .. "," ..
-                             score.time .. "," ..
-                             (score.clearTime or "none")
-                             
-                             
-            modeStr = modeStr .. scoreStr .. "\n"
+        table.sort(HighScores[mode_id], function(a, b) return tonumber(a.score) > tonumber(b.score) end)
+
+        local mode_str = ("[%s]\n"):format(mode_id)
+        for _, score in ipairs(HighScores[mode_id]) do
+            local score_str = ("%s,%s,%s,%s,%s,%s,%s"):format(
+                score.score, score.clear_score or "none", score.lines,
+                score.start_level, score.final_level, score.time,
+                score.clear_time or "none"
+            )
+            mode_str = mode_str..score_str.."\n"
         end
-        str = str .. modeStr .."\n"
+        str = str..mode_str.."\n"
     end
     local success, message = love.filesystem.write("highscores.sav", str:sub(1,-2))
 end

--- a/main.lua
+++ b/main.lua
@@ -550,7 +550,7 @@ function love.draw()
         until (not lastentry) or lastentry.time + 3 > Game.time
         table.insert(Game.recent_actions, lastentry)
         local yscoff = 0
-        for i, entry in ipairs(Game.recent_actions) do
+        for _, entry in ipairs(Game.recent_actions) do
             local t = (Game.time - entry.time)/3
             local ysc, xsc = 1-(1-t)^15, 1-t^10
             yscoff = yscoff + ysc

--- a/main.lua
+++ b/main.lua
@@ -361,6 +361,7 @@ function love.draw()
 				DrawInfinitySymbol(Width*0.5 + posx - scx/10, math.floor(Height*0.7), 0, -scx/10, scy/6)
 			end
 		end
+		--TODO: Refactor this place
 		if Title.current == "highscores" then
 			local mode = Title.highscores.modeList[Title.highscores.selection]
 			local current_scores = HighScores[mode]
@@ -374,17 +375,17 @@ function love.draw()
 				if(Title.highscores.showclear) then
 					local textw = charw*40
 					leftx = Width*0.5-textw/2
-					love.graphics.printf("CLEAR SCORE",math.floor(leftx+charw*6),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("START LV",      math.floor(leftx+charw*19),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("LEVEL",         math.floor(leftx+charw*26),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("CLEAR TIME", math.floor(leftx+charw*32),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("CLEAR SCORE", math.floor(leftx+charw*6),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("START LV",    math.floor(leftx+charw*19),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("LEVEL",       math.floor(leftx+charw*26),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("CLEAR TIME",  math.floor(leftx+charw*32),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
 				else
 					local textw = charw*41
 					leftx = Width*0.5-textw/2
-					love.graphics.printf("SCORE",math.floor(leftx+charw*6),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("LINES",math.floor(leftx+charw*20),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("LEVEL",math.floor(leftx+charw*27),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("TIME", math.floor(leftx+charw*33),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("SCORE", math.floor(leftx+charw*6),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("LINES", math.floor(leftx+charw*20),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("LEVEL", math.floor(leftx+charw*27),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					love.graphics.printf("TIME",  math.floor(leftx+charw*33),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
 				end
 				love.graphics.setFont(Font.Menu)
 				local curve = Levels[Title.highscores.modeIndices[mode]]

--- a/main.lua
+++ b/main.lua
@@ -353,7 +353,8 @@ function love.draw()
         love.graphics.draw(CanvasBG)
 		love.graphics.setColor(1,1,1)
 		love.graphics.draw(Title[Title.current].text)
-		if Title.current == "play" then
+
+        if Title.current == "play" then
 			local modeid = Title.play.items[Title.play.highlight].id
 			if modeid and Levels[modeid][Title.play.startlv].level_name == math.huge then
 				local scx, scy = Font.Menu:getWidth("AA"), Font.Menu:getHeight()
@@ -361,67 +362,67 @@ function love.draw()
 				DrawInfinitySymbol(Width*0.5 + posx - scx/10, math.floor(Height*0.7), 0, -scx/10, scy/6)
 			end
 		end
-		--TODO: Refactor this place
+
 		if Title.current == "highscores" then
-			local mode = Title.highscores.modeList[Title.highscores.selection]
+			local mode = Title.highscores.mode_list[Title.highscores.selection]
 			local current_scores = HighScores[mode]
 			if(#current_scores == 0) then
 				love.graphics.printf("[ NO HIGH SCORES TO DISPLAY ]",0,Height*0.3,Width,"center")
 			else
 				-- title bar
 				love.graphics.setFont(Font.HUD)
-				local charw = Font.Menu:getWidth("A")
-				local leftx -- for use later
-				if(Title.highscores.showclear) then
-					local textw = charw*40
-					leftx = Width*0.5-textw/2
-					love.graphics.printf("CLEAR SCORE", math.floor(leftx+charw*6),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("START LV",    math.floor(leftx+charw*19),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("LEVEL",       math.floor(leftx+charw*26),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("CLEAR TIME",  math.floor(leftx+charw*32),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+				local char_width = Font.Menu:getWidth("A")
+				local left_x -- for use later
+				if(Title.highscores.show_clear) then
+					local text_width = char_width *40
+					left_x  = Width*0.5- text_width /2
+					love.graphics.printf("CLEAR SCORE", math.floor(left_x + char_width *6),  Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
+					love.graphics.printf("START LV",    math.floor(left_x + char_width *19), Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
+					love.graphics.printf("LEVEL",       math.floor(left_x + char_width *26), Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
+					love.graphics.printf("CLEAR TIME",  math.floor(left_x + char_width *32), Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
 				else
-					local textw = charw*41
-					leftx = Width*0.5-textw/2
-					love.graphics.printf("SCORE", math.floor(leftx+charw*6),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("LINES", math.floor(leftx+charw*20),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("LEVEL", math.floor(leftx+charw*27),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
-					love.graphics.printf("TIME",  math.floor(leftx+charw*33),Height*0.3-Font.HUD:getHeight()*1.1,Width*0.5,"left")
+					local textw = char_width *41
+					left_x = Width*0.5-textw/2
+					love.graphics.printf("SCORE", math.floor(left_x + char_width *6),  Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
+					love.graphics.printf("LINES", math.floor(left_x + char_width *20), Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
+					love.graphics.printf("LEVEL", math.floor(left_x + char_width *27), Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
+					love.graphics.printf("TIME",  math.floor(left_x + char_width *33), Height*0.3-Font.HUD:getHeight()*1.1, Width*0.5, "left")
 				end
 				love.graphics.setFont(Font.Menu)
-				local curve = Levels[Title.highscores.modeIndices[mode]]
+				local curve = Levels[Title.highscores.mode_indices[mode]]
 				local function levelStr(l)
 					-- Removes the level text if it's Lv. Inf so it can draw the infinity symbol instead
-					return (l ~= math.huge and l or "")
+					return l ~= math.huge and l or ""
 				end
-				for i=1,math.min(#current_scores,10) do
+				for i = 1, math.min(#current_scores, 10) do
 					local score = current_scores[i]
 					local st = ""
-					if(Title.highscores.showclear) then
+					if(Title.highscores.show_clear) then
 						st = string.format("#%2s -%12s - %3s - %3s -%9s",
 											i,
-											score.clearScore and CommaValue(score.clearScore) or "NO CLEAR",
-											levelStr(curve[score.startLevel].level_name),
-											levelStr(curve[score.finalLevel].level_name),
-											score.clearTime and FormatTime(score.clearTime) or "XX\'XX\"XX")
-						if(curve[score.startLevel].level_name == math.huge) then
-							DrawInfinitySymbol(leftx+charw*(22+5/6), Height*0.3+(i-1)*Font.Menu:getHeight(), 0, -(charw*2)/10, Font.Menu:getHeight()/6)
+											score.clear_score and CommaValue(score.clear_score) or "NO CLEAR",
+											levelStr(curve[score.start_level].level_name),
+											levelStr(curve[score.final_level].level_name),
+											score.clear_time and FormatTime(score.clear_time) or "XX\'XX\"XX")
+						if(curve[score.start_level].level_name == math.huge) then
+							DrawInfinitySymbol(left_x + char_width *(22+5/6), Height*0.3+(i-1)*Font.Menu:getHeight(), 0, -(char_width *2)/10, Font.Menu:getHeight()/6)
 						end
-						if(curve[score.finalLevel].level_name == math.huge) then
-							DrawInfinitySymbol(leftx+charw*(28+5/6), Height*0.3+(i-1)*Font.Menu:getHeight(), 0, -(charw*2)/10, Font.Menu:getHeight()/6)
+						if(curve[score.final_level].level_name == math.huge) then
+							DrawInfinitySymbol(left_x + char_width *(28+5/6), Height*0.3+(i-1)*Font.Menu:getHeight(), 0, -(char_width *2)/10, Font.Menu:getHeight()/6)
 						end
 					else
 						st = string.format("#%2s -%12s -%5d - %3s -%9s",
-											i,
-											tonumber(score.score) >= 1000000000 and score.score or CommaValue(score.score),
-											score.lines,
-											levelStr(curve[score.finalLevel].level_name),
-											FormatTime(score.time))
-						if(curve[score.finalLevel].level_name == math.huge) then
-							DrawInfinitySymbol(leftx+charw*(29+5/6), Height*0.3+(i-1)*Font.Menu:getHeight(), 0, -(charw*2)/10, Font.Menu:getHeight()/6)
+                                            i,
+                                            tonumber(score.score) >= 1000000000 and score.score or CommaValue(score.score),
+                                            score.lines,
+                                            levelStr(curve[score.final_level].level_name),
+                                            FormatTime(score.time))
+						if(curve[score.final_level].level_name == math.huge) then
+							DrawInfinitySymbol(left_x + char_width *(29+5/6), Height*0.3+(i-1)*Font.Menu:getHeight(), 0, -(char_width *2)/10, Font.Menu:getHeight()/6)
 						end
 					end
 							
-					love.graphics.printf(st,0,Height*0.3+(i-1)*Font.Menu:getHeight(),Width,"center")
+					love.graphics.printf(st, 0, Height*0.3+(i-1)*Font.Menu:getHeight(), Width, "center")
 				end
 			end
 		end

--- a/menu.lua
+++ b/menu.lua
@@ -18,36 +18,50 @@
 Menu = {
 	updateSelected = function(self, key)
 		local r
-		    if key == "up"     then self.highlight = (self.highlight - 2) % #self.items + 1
-		elseif key == "down"   then self.highlight = (self.highlight - 0) % #self.items + 1
-		elseif key == "return" then r = self.items[self.highlight]:action_e()
-		elseif key == "right"  then r = self.items[self.highlight]:action_r()
-		elseif key == "left"   then r = self.items[self.highlight]:action_l()
-		end
-        self.text:setFont(Font[self.font])
-		self.text:set("")
-		for k, item in ipairs(self.items) do
-			self.text:addf({k == self.highlight and {1, 0.7, 0.5} or {1,1,1}, item.label}, Width, "center", math.floor(item.x*Width/2), math.floor(item.y*Height/2)+Height/2)
-		end
+            if key == "up"     then self.highlight = (self.highlight - 2) % #self.items + 1
+        elseif key == "down"   then self.highlight = (self.highlight - 0) % #self.items + 1
+        elseif key == "return" then r = self.items[self.highlight]:action_e()
+        elseif key == "right"  then r = self.items[self.highlight]:action_r()
+        elseif key == "left"   then r = self.items[self.highlight]:action_l()
+        else for _, item in ipairs(self.items) do item:update() end
+        end
+
+        self:updateItem(self.highlight)
+
 		return r
 	end,
-    
-    reload = function(menu)
-        -- local fontsize = menu.font
+
+    reload = function(self)
+        -- local fontsize = self.font
         -- local font
             -- if fontsize == "big"   then font = HUDFontBig
         -- elseif fontsize == "small" then font = HUDFontSmall
         -- else font = HUDFont
         -- end
-        -- menu.text:setFont(font)
-        menu:updateSelected("kek")
+        -- self.text:setFont(font)
+        self:updateSelected("kek")
     end,
-	
-	new = function(font, items)
-		for k = 1, #items do
-			if not items[k].action_e then items[k].action_e = NADA end
-			if not items[k].action_l then items[k].action_l = NADA end
-			if not items[k].action_r then items[k].action_r = NADA end
+
+    updateItem = function(self, index)
+        self.items[index]:update()
+
+        self.text:setFont(Font[self.font])
+		self.text:set("")
+		for k, item in ipairs(self.items) do
+			self.text:addf({k == index and {1, 0.7, 0.5} or {1,1,1}, item.label},
+                            Width, "center",
+                            math.floor(item.x*Width/2),
+                            math.floor(item.y*Height/2)+Height/2)
+		end
+	end,
+
+    new = function(font, items)
+        for k = 1, #items do
+            if not items[k].action_e 	then items[k].action_e  = NADA end
+            if not items[k].action_l 	then items[k].action_l  = NADA end
+            if not items[k].action_r 	then items[k].action_r  = NADA end
+            if not items[k].update 	    then items[k].update    = NADA end
+            items[k].index = k
 		end
 		--[[
         local font
@@ -56,12 +70,13 @@ Menu = {
         else font = HUDFont
         end]]
 		local menu = {
-			items = items,
-            font = font,
-			text = love.graphics.newText(Font[font]),
-			highlight = 1,
-			updateSelected = Menu.updateSelected,
-            reload = Menu.reload,
+			items           = items,
+            font            = font,
+			text            = love.graphics.newText(Font[font]),
+			highlight       = 1,
+			updateItem      = Menu.updateItem,
+			updateSelected  = Menu.updateSelected,
+            reload          = Menu.reload,
 		}
 		for k = 1, #menu.items do menu.items[k].parent = menu end
 		menu:updateSelected("kek")

--- a/menu.lua
+++ b/menu.lua
@@ -17,18 +17,21 @@
 
 Menu = {
 	updateSelected = function(self, key)
-		local r
             if key == "up"     then self.highlight = (self.highlight - 2) % #self.items + 1
         elseif key == "down"   then self.highlight = (self.highlight - 0) % #self.items + 1
-        elseif key == "return" then r = self.items[self.highlight]:action_e()
-        elseif key == "right"  then r = self.items[self.highlight]:action_r()
-        elseif key == "left"   then r = self.items[self.highlight]:action_l()
-        else for _, item in ipairs(self.items) do item:update() end
+        elseif key == "return" then r = self.items[self.highlight]:action_e(); self.items[self.highlight]:update()
+        elseif key == "right"  then r = self.items[self.highlight]:action_r(); self.items[self.highlight]:update()
+        elseif key == "left"   then r = self.items[self.highlight]:action_l(); self.items[self.highlight]:update()
         end
 
-        self:updateItem(self.highlight)
-
-		return r
+        self.text:setFont(Font[self.font])
+        self.text:set("")
+		for k, item in ipairs(self.items) do
+			self.text:addf({k == self.highlight and {1, 0.7, 0.5} or {1,1,1}, item.label},
+                            Width, "center",
+                            math.floor(item.x*Width/2),
+                            math.floor(item.y*Height/2)+Height/2)
+		end
 	end,
 
     reload = function(self)
@@ -42,25 +45,12 @@ Menu = {
         self:updateSelected("kek")
     end,
 
-    updateItem = function(self, index)
-        self.items[index]:update()
-
-        self.text:setFont(Font[self.font])
-		self.text:set("")
-		for k, item in ipairs(self.items) do
-			self.text:addf({k == index and {1, 0.7, 0.5} or {1,1,1}, item.label},
-                            Width, "center",
-                            math.floor(item.x*Width/2),
-                            math.floor(item.y*Height/2)+Height/2)
-		end
-	end,
-
     new = function(font, items)
         for k = 1, #items do
-            if not items[k].action_e 	then items[k].action_e  = NADA end
-            if not items[k].action_l 	then items[k].action_l  = NADA end
-            if not items[k].action_r 	then items[k].action_r  = NADA end
-            if not items[k].update 	    then items[k].update    = NADA end
+            if not items[k].action_e then items[k].action_e = NADA end
+            if not items[k].action_l then items[k].action_l = NADA end
+            if not items[k].action_r then items[k].action_r = NADA end
+            if not items[k].update 	 then items[k].update   = NADA end
             items[k].index = k
 		end
 		--[[
@@ -70,13 +60,12 @@ Menu = {
         else font = HUDFont
         end]]
 		local menu = {
-			items           = items,
-            font            = font,
-			text            = love.graphics.newText(Font[font]),
-			highlight       = 1,
-			updateItem      = Menu.updateItem,
-			updateSelected  = Menu.updateSelected,
-            reload          = Menu.reload,
+			items          = items,
+            font           = font,
+			text           = love.graphics.newText(Font[font]),
+			highlight      = 1,
+			updateSelected = Menu.updateSelected,
+            reload         = Menu.reload,
 		}
 		for k = 1, #menu.items do menu.items[k].parent = menu end
 		menu:updateSelected("kek")

--- a/menu.lua
+++ b/menu.lua
@@ -19,9 +19,9 @@ Menu = {
 	updateSelected = function(self, key)
             if key == "up"     then self.highlight = (self.highlight - 2) % #self.items + 1
         elseif key == "down"   then self.highlight = (self.highlight - 0) % #self.items + 1
-        elseif key == "return" then r = self.items[self.highlight]:action_e(); self.items[self.highlight]:update()
-        elseif key == "right"  then r = self.items[self.highlight]:action_r(); self.items[self.highlight]:update()
-        elseif key == "left"   then r = self.items[self.highlight]:action_l(); self.items[self.highlight]:update()
+        elseif key == "return" then self.items[self.highlight]:action_e(); self.items[self.highlight]:update()
+        elseif key == "right"  then self.items[self.highlight]:action_r(); self.items[self.highlight]:update()
+        elseif key == "left"   then self.items[self.highlight]:action_l(); self.items[self.highlight]:update()
         end
 
         self.text:setFont(Font[self.font])

--- a/splash.lua
+++ b/splash.lua
@@ -26,7 +26,7 @@ local splashcanvas = love.graphics.newCanvas(1600, 900)
 function ResetSplashScreen(t) splashtime = t or 0 end -- idk maybe itll be useful
 
 function UpdateSplashScreen(dt)
-    if splashtime < 4 then
+    if not love.keyboard.isDown("return") and splashtime < 4 then
         splashtime = splashtime + dt
     else
         love.graphics.setCanvas(CanvasBG)

--- a/title.lua
+++ b/title.lua
@@ -22,9 +22,9 @@ local change = function(menu) return function(button) button.parent.highlight = 
 local open   = function(menu) return function(button)                              SaveConfig(); Title.current = menu end end
 
 Title.main = Menu.new("Menu", {
-	{x = 0, y = -0.2, label = "START GAME",      action_e = open("play")},
-	{x = 0, y =  0.0, label = "SETTINGS",        action_e = open("settings")},
-	{x = 0, y =  0.2, label = "HIGH SCORES",     action_e = open("highscores")}
+	{x = 0, y = -0.2, label = "START GAME",  action_e = open("play")},
+	{x = 0, y =  0.0, label = "SETTINGS",    action_e = open("settings")},
+	{x = 0, y =  0.2, label = "HIGH SCORES", action_e = open("highscores")}
 	--[[
 	{x = 0, y =  0.2, label = "Networking test",
 		action_e = function(button)
@@ -112,53 +112,37 @@ end
 Title.play:updateSelected()
 
 Title.settings = Menu.new("Menu", {
-	{x = 0, y = -0.3, label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume),
+    {x = 0, y = -0.3, label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume),
 		action_e = function(button)
-			local n = (tonumber(Config.bgm_volume) + 5) % 105
-			Config.bgm_volume = tostring(n)
-			button.label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume)
-            SetBGMVolume(n/100)
-            SaveConfig()
+			Config.bgm_volume = tostring((tonumber(Config.bgm_volume) + 5) % 105)
 		end,
 		action_r = function(button)
-			local n = math.min(tonumber(Config.bgm_volume) + 5, 100)
-			Config.bgm_volume = tostring(n)
-			button.label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume)
-            SetBGMVolume(n/100)
-            SaveConfig()
+			Config.bgm_volume = tostring(math.min(tonumber(Config.bgm_volume) + 5, 100))
 		end,
 		action_l = function(button)
-			local n = math.max(tonumber(Config.bgm_volume) - 5, 0)
-			Config.bgm_volume = tostring(n)
-			button.label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume)
-            SetBGMVolume(n/100)
-            SaveConfig()
+			Config.bgm_volume = tostring(math.max(tonumber(Config.bgm_volume) - 5, 0))
 		end,
+        update = function(button)
+            button.label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume)
+            SetBGMVolume(tonumber(Config.bgm_volume)/100)
+        end
     },
 	{x = 0, y = -0.2, label = ("< SFX VOLUME : %d%% >"):format(Config.sfx_volume),
 		action_e = function(button)
-			local n = (tonumber(Config.sfx_volume) + 5) % 105
-			Config.sfx_volume = tostring(n)
-			button.label = ("< SFX VOLUME : %d%% >"):format(Config.sfx_volume)
-            SetSFXVolume(n/100)
-            SaveConfig()
+			Config.sfx_volume = tostring((tonumber(Config.sfx_volume) + 5) % 105)
 		end,
 		action_r = function(button)
-			local n = math.min(tonumber(Config.sfx_volume) + 5, 100)
-			Config.sfx_volume = tostring(n)
-			button.label = ("< SFX VOLUME : %d%% >"):format(Config.sfx_volume)
-            SetSFXVolume(n/100)
-            SaveConfig()
+			Config.sfx_volume = tostring(math.min(tonumber(Config.sfx_volume) + 5, 100))
 		end,
 		action_l = function(button)
-			local n = math.max(tonumber(Config.sfx_volume) - 5, 0)
-			Config.sfx_volume = tostring(n)
-			button.label = ("< SFX VOLUME : %d%% >"):format(Config.sfx_volume)
-            SetSFXVolume(n/100)
-            SaveConfig()
+			Config.sfx_volume = tostring(math.max(tonumber(Config.sfx_volume) - 5, 0))
 		end,
+        update = function(button)
+			button.label = ("< SFX VOLUME : %d%% >"):format(Config.sfx_volume)
+            SetSFXVolume(tonumber(Config.sfx_volume)/100)
+        end
     },
-    
+
 	{x = 0, y =  0.0, label = "KEYBOARD CONFIG",  action_e = open("keyconf")},
 	{x = 0, y =  0.1, label = "GAMEPAD CONFIG",   action_e = open("padconf")},
 	{x = 0, y =  0.3, label = "GRAPHICS OPTIONS", action_e = open("graphics")},
@@ -170,20 +154,17 @@ local keySettingsItems = {}
 local padSettingsItems = {
 	{x = 0, y = -0.4, label = ("< AXIS DEADZONE : %d%% >"):format(Config.pad_deadzone),
 		action_e = function(button)
-			local n = (tonumber(Config.pad_deadzone) + 5) % 105
-			Config.pad_deadzone = tostring(n)
-			button.label = ("< AXIS DEADZONE : %d%% >"):format(Config.pad_deadzone)
+			Config.pad_deadzone = tostring((tonumber(Config.pad_deadzone) + 5) % 105)
 		end,
 		action_r = function(button)
-			local n = math.min(tonumber(Config.pad_deadzone) + 5, 100)
-			Config.pad_deadzone = tostring(n)
-			button.label = ("< AXIS DEADZONE : %d%% >"):format(Config.pad_deadzone)
+			Config.pad_deadzone = tostring(math.min(tonumber(Config.pad_deadzone) + 5, 100))
 		end,
 		action_l = function(button)
-			local n = math.max(tonumber(Config.pad_deadzone) - 5, 0)
-			Config.pad_deadzone = tostring(n)
-			button.label = ("< AXIS DEADZONE : %d%% >"):format(Config.pad_deadzone)
+			Config.pad_deadzone = tostring(math.max(tonumber(Config.pad_deadzone) - 5, 0))
 		end,
+        update = function(button)
+            button.label = ("< AXIS DEADZONE : %d%% >"):format(Config.pad_deadzone)
+        end
 	},
 }
 for i = 1, #Bindlist do
@@ -210,222 +191,191 @@ Title.graphics = Menu.new("Menu", {
 	{x = 0, y = -0.4,
 		label = ("MATRIX SWAY AMPLITUDE: <%s%s>"):format(("|"):rep(tonumber(Config.sway_amplitude)), ("."):rep(10 - tonumber(Config.sway_amplitude))),
 		action_e = function(button)
-			local n = (tonumber(Config.sway_amplitude) + 1) % 10
-			button.label = ("MATRIX SWAY AMPLITUDE: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_amplitude = tostring(n)
+			Config.sway_amplitude = tostring((tonumber(Config.sway_amplitude) + 1) % 10)
 		end,
 		action_r = function(button)
-			local n = math.min(10, tonumber(Config.sway_amplitude) + 1)
-			button.label = ("MATRIX SWAY AMPLITUDE: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_amplitude = tostring(n)
+			Config.sway_amplitude = tostring(math.min(10, tonumber(Config.sway_amplitude) + 1))
 		end,
 		action_l = function(button)
-			local n = math.max(0, tonumber(Config.sway_amplitude) - 1)
-			button.label = ("MATRIX SWAY AMPLITUDE: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_amplitude = tostring(n)
+			Config.sway_amplitude = tostring(math.max(0, tonumber(Config.sway_amplitude) - 1))
 		end,
+        update = function(button)
+            button.label = ("MATRIX SWAY AMPLITUDE: <%s%s>"):format(("|"):rep(Config.sway_amplitude), ("."):rep(10 - Config.sway_amplitude))
+        end
 	},
 	{x = 0, y = -0.3,
 		label = ("MATRIX SWAY SPEED: <%s%s>"):format(("|"):rep(tonumber(Config.sway_speed)), ("."):rep(10 - tonumber(Config.sway_speed))),
 		action_e = function(button)
-			local n = (tonumber(Config.sway_speed) % 10) + 1
-			button.label = ("MATRIX SWAY SPEED: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_speed = tostring(n)
+			Config.sway_speed = tostring((tonumber(Config.sway_speed) % 10) + 1)
 		end,
 		action_r = function(button)
-			local n = math.min(10, tonumber(Config.sway_speed) + 1)
-			button.label = ("MATRIX SWAY SPEED: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_speed = tostring(n)
+			Config.sway_speed = tostring(math.min(10, tonumber(Config.sway_speed) + 1))
 		end,
 		action_l = function(button)
-			local n = math.max(1, tonumber(Config.sway_speed) - 1)
-			button.label = ("MATRIX SWAY SPEED: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_speed = tostring(n)
+			Config.sway_speed = tostring(math.max(1, tonumber(Config.sway_speed) - 1))
 		end,
+        update = function(button)
+            button.label = ("MATRIX SWAY SPEED: <%s%s>"):format(("|"):rep(Config.sway_speed), ("."):rep(10 - Config.sway_speed))
+        end
 	},
 	{x = 0, y = -0.2,
 		label = ("MATRIX SWAY BOUNCINESS: <%s%s>"):format(("|"):rep(tonumber(Config.sway_bounciness)), ("."):rep(10 - tonumber(Config.sway_bounciness))),
 		action_e = function(button)
-			local n = (tonumber(Config.sway_bounciness) % 10) + 1
-			button.label = ("MATRIX SWAY BOUNCINESS: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_bounciness = tostring(n)
+			Config.sway_bounciness = tostring((tonumber(Config.sway_bounciness) % 10) + 1)
 		end,
 		action_r = function(button)
-			local n = math.min(10, tonumber(Config.sway_bounciness) + 1)
-			button.label = ("MATRIX SWAY BOUNCINESS: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_bounciness = tostring(n)
+			Config.sway_bounciness = tostring(math.min(10, tonumber(Config.sway_bounciness) + 1))
 		end,
 		action_l = function(button)
-			local n = math.max(1, tonumber(Config.sway_bounciness) - 1)
-			button.label = ("MATRIX SWAY BOUNCINESS: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.sway_bounciness = tostring(n)
+			Config.sway_bounciness = tostring(math.max(1, tonumber(Config.sway_bounciness) - 1))
 		end,
+        update = function(button)
+            button.label = ("MATRIX SWAY BOUNCINESS: <%s%s>"):format(("|"):rep(Config.sway_bounciness), ("."):rep(10 - Config.sway_bounciness))
+        end
 	},
 	{x = 0, y =  0.1, label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg),
-		action_e = function(button)
-			Config.dynamic_bg = (Config.dynamic_bg == "O" and "X" or "O")
-			button.label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg)
+        update = function(button)
+            Config.dynamic_bg = (Config.dynamic_bg == "O" and "X" or "O")
+            button.label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg)
             if Config.dynamic_bg == "X" then PrerenderBG() end
-            SaveConfig()
-		end,
-		action_r = function(button)
-			Config.dynamic_bg = (Config.dynamic_bg == "O" and "X" or "O")
-			button.label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg)
-            if Config.dynamic_bg == "X" then PrerenderBG() end
-            SaveConfig()
-		end,
-		action_l = function(button)
-			Config.dynamic_bg = (Config.dynamic_bg == "O" and "X" or "O")
-			button.label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg)
-            if Config.dynamic_bg == "X" then PrerenderBG() end
-            SaveConfig()
-		end,
+        end
     },
 	{x = 0, y =  0.2, label = ("< BACKGROUND BRIGHTNESS : %d%% >"):format(Config.bg_brightness),
 		action_e = function(button)
-			local n = (tonumber(Config.bg_brightness) + 5) % 105
-			Config.bg_brightness = tostring(n)
-			button.label = ("< BACKGROUND BRIGHTNESS : %d%% >"):format(Config.bg_brightness)
-            SaveConfig()
+			Config.bg_brightness = tostring((tonumber(Config.bg_brightness) + 5) % 105)
 		end,
 		action_r = function(button)
-			local n = math.min(tonumber(Config.bg_brightness) + 5, 100)
-			Config.bg_brightness = tostring(n)
-			button.label = ("< BACKGROUND BRIGHTNESS : %d%% >"):format(Config.bg_brightness)
-            SaveConfig()
+			Config.bg_brightness = tostring(math.min(tonumber(Config.bg_brightness) + 5, 100))
 		end,
 		action_l = function(button)
-			local n = math.max(tonumber(Config.bg_brightness) - 5, 0)
-			Config.bg_brightness = tostring(n)
-			button.label = ("< BACKGROUND BRIGHTNESS : %d%% >"):format(Config.bg_brightness)
-            SaveConfig()
+			Config.bg_brightness = tostring(math.max(tonumber(Config.bg_brightness) - 5, 0))
 		end,
+        update = function(button)
+            button.label = ("< BACKGROUND BRIGHTNESS : %d%% >"):format(Config.bg_brightness)
+        end
     },
-	{x = 0, y =  0.3,
-		label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(tonumber(Config.blur_spread)), ("."):rep(10 - tonumber(Config.blur_spread))),
+	{x = 0, y =  0.3, label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(tonumber(Config.blur_spread)), ("."):rep(10 - tonumber(Config.blur_spread))),
 		action_e = function(button)
-			local n = (tonumber(Config.blur_spread) % 10)
-			button.label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.blur_spread = tostring(n)
+			Config.blur_spread = tostring((tonumber(Config.blur_spread) % 10))
 		end,
 		action_r = function(button)
-			local n = math.min(10, tonumber(Config.blur_spread) + 1)
-			button.label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.blur_spread = tostring(n)
+			Config.blur_spread = tostring(math.min(10, tonumber(Config.blur_spread) + 1))
 		end,
 		action_l = function(button)
-			local n = math.max(0, tonumber(Config.blur_spread) - 1)
-			button.label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.blur_spread = tostring(n)
+			Config.blur_spread = tostring(math.max(0, tonumber(Config.blur_spread) - 1))
 		end,
+        update = function(button)
+            button.label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(Config.blur_spread), ("."):rep(10 - Config.blur_spread))
+        end
 	},
-	{x = 0, y =  0.4,
-		label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(tonumber(Config.trail_duration)), ("."):rep(10 - tonumber(Config.trail_duration))),
+	{x = 0, y =  0.4, label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(tonumber(Config.trail_duration)), ("."):rep(10 - tonumber(Config.trail_duration))),
 		action_e = function(button)
-			local n = (tonumber(Config.trail_duration) % 10)
-			button.label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.trail_duration = tostring(n)
+			Config.trail_duration = tostring((tonumber(Config.trail_duration) % 10))
 		end,
 		action_r = function(button)
-			local n = math.min(10, tonumber(Config.trail_duration) + 1)
-			button.label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.trail_duration = tostring(n)
+			Config.trail_duration = tostring(math.min(10, tonumber(Config.trail_duration) + 1))
 		end,
 		action_l = function(button)
-			local n = math.max(0, tonumber(Config.trail_duration) - 1)
-			button.label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(n), ("."):rep(10 - n))
-			Config.trail_duration = tostring(n)
+			Config.trail_duration = tostring(math.max(0, tonumber(Config.trail_duration) - 1))
 		end,
+        update = function(button)
+            button.label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(Config.trail_duration), ("."):rep(10 - Config.trail_duration))
+        end
 	},
 	{x = 0, y =  0.7, label = "BACK", action_e = change("settings")},
 })
 
 Title.window = Menu.new("Menu", {
-	{x = 0, y =  -0.4, param = CurrentScreen, prev_screen = CurrentScreen,
+	{x = 0, y =  -0.4, param = 1, prev_screen = 1, label = ("< SCREEN : %s >"):format(1),
 		action_e = function(button)
-            button.prev_screen = CurrentScreen
-			CurrentScreen = (CurrentScreen % #FullScreenModes) + 1
+            button.prev_screen = button.param
+			button.param = (button.param % #FullScreenModes) + 1
 		end,
 		action_r = function(button)
-			button.prev_screen = CurrentScreen
-            CurrentScreen = (CurrentScreen % #FullScreenModes) + 1
+			button.prev_screen = button.param
+            button.param = (button.param % #FullScreenModes) + 1
 		end,
 		action_l = function(button)
-			button.prev_screen = CurrentScreen
-            CurrentScreen = ((CurrentScreen - 2) % #FullScreenModes) + 1
+			button.prev_screen = button.param
+            button.param = ((button.param - 2) % #FullScreenModes) + 1
 		end,
         update = function(button)
-            button.label = ("< SCREEN : %s >"):format(CurrentScreen)
+            button.label = ("< SCREEN : %s >"):format(button.param)
 
-            local cur_res_param     = button.parent.items[button.index+1].param
-            local aprox_switch_res  = math.floor((cur_res_param/#FullScreenModes[button.prev_screen])*#FullScreenModes[CurrentScreen])
-            button.parent.items[button.index+1].param = math.clamp(aprox_switch_res, 1, #FullScreenModes[CurrentScreen])
+			local prev_resolution_id = button.parent.items[2].param
+            local prev_resolutions   = FullScreenModes[button.prev_screen]
+            local cur_resolutions    = FullScreenModes[button.param]
+            local prev_mode          = prev_resolutions[prev_resolution_id]
 
-            button.parent:updateItem(button.index+1) -- Updates `RESOLUTION` item to match a selected screen's resolutions.
+            local res_id_found
+            for i, mode in pairs(cur_resolutions) do
+                if mode.width == prev_mode.width and mode.height == prev_mode.height then
+                    res_id_found = i
+                    break
+                elseif (mode.width > prev_mode.width and mode.height == prev_mode.height) or
+                        mode.height > prev_mode.height then
+                    res_id_found = i-1
+                    break
+                end
+            end
+            if not res_id_found then res_id_found = #cur_resolutions end
+
+            -- Updates `RESOLUTION` item to match a selected screen's resolutions.
+            button.parent.items[2].param = res_id_found
+            button.parent.items[2]:update(2)
         end
     },
 
-	{x = 0, y = -0.2, param = 1,
+	{x = 0, y = -0.2, param = 1, label = ("< RESOLUTION : %4dx%4d >"):format("640", "480"),
 		action_e = function(button)
-			button.param = (button.param % #FullScreenModes[CurrentScreen]) + 1
+			local cur_screen = button.parent.items[1].param
+			button.param = (button.param % #FullScreenModes[cur_screen]) + 1
 		end,
 		action_r = function(button)
-			button.param = (button.param % #FullScreenModes[CurrentScreen]) + 1
+			local cur_screen = button.parent.items[1].param
+			button.param = (button.param % #FullScreenModes[cur_screen]) + 1
 		end,
 		action_l = function(button)
-			button.param = ((button.param - 2) % #FullScreenModes[CurrentScreen]) + 1
+			local cur_screen = button.parent.items[1].param
+			button.param = ((button.param - 2) % #FullScreenModes[cur_screen]) + 1
 		end,
 		update = function(button)
-			local mode = FullScreenModes[CurrentScreen][button.param]
-			--button.label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(mode.width, mode.height, CurrentScreen) -- Debuge
+			local cur_screen = button.parent.items[1].param
+			local mode = FullScreenModes[cur_screen][button.param]
+			--button.label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(mode.width, mode.height, cur_screen) -- Debuge
 			button.label = ("< RESOLUTION : %4dx%4d >"):format(mode.width, mode.height)
 		end
     },
 
-	{x = 0, y = 0.1, param = Config.fullscreen,
-		action_e = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-		end,
-		action_r = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-		end,
-		action_l = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-		end,
+	{x = 0, y = 0.1, param = Config.fullscreen, label = ("< FULLSCREEN : %s >"):format(Config.fullscreen),
         update = function(button)
+            button.param = (button.param == "O" and "X" or "O")
             button.label = ("< FULLSCREEN : %s >"):format(button.param)
         end
     },
 
-	{x = 0, y = 0.2, param = Config.vsync,
-		action_e = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-		end,
-		action_r = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-		end,
-		action_l = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-		end,
+	{x = 0, y = 0.2, param = Config.vsync, label = ("< VSYNC : %s >"):format(Config.vsync),
         update = function(button)
+            button.param = (button.param == "O" and "X" or "O")
             button.label = ("< VSYNC : %s >"):format(button.param)
         end
     },
 	
 	{x = 0, y = 0.5, label = "APPLY",
 		action_e = function(button)
-			local buttons   = button.parent.items
-			local mode      = FullScreenModes[CurrentScreen][buttons[2].param]
+			local buttons = button.parent.items
+			local display = buttons[1].param
+			local mode    = FullScreenModes[display][buttons[2].param]
 
-			local width, height, display    = mode.width, mode.height, CurrentScreen
-			local fs, vsync                 = buttons[3].param, buttons[4].param
+			local width, height = mode.width, mode.height
+			local fs, vsync     = buttons[3].param, buttons[4].param
 
             SetDisplayMode(width, height, display, fs == "O", vsync == "O")
-			Config.window_width     = tostring(width  )
-			Config.window_height    = tostring(height )
-			Config.window_display   = tostring(display)
-			Config.fullscreen       = fs
-			Config.vsync            = vsync
+			Config.window_width   = tostring(width  )
+			Config.window_height  = tostring(height )
+			Config.window_display = tostring(display)
+			Config.fullscreen     = fs
+			Config.vsync          = vsync
 		end
 	},
 

--- a/title.lua
+++ b/title.lua
@@ -112,7 +112,7 @@ end
 Title.play:updateSelected()
 
 Title.settings = Menu.new("Menu", {
-    {x = 0, y = -0.3, label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume),
+    {x = 0, y = -0.3, label = ("BGM VOLUME : < %d%% >"):format(Config.bgm_volume),
 		action_e = function(button)
 			Config.bgm_volume = tostring((tonumber(Config.bgm_volume) + 5) % 105)
 		end,
@@ -123,11 +123,11 @@ Title.settings = Menu.new("Menu", {
 			Config.bgm_volume = tostring(math.max(tonumber(Config.bgm_volume) - 5, 0))
 		end,
         update = function(button)
-            button.label = ("< BGM VOLUME : %d%% >"):format(Config.bgm_volume)
+            button.label = ("BGM VOLUME : < %d%% >"):format(Config.bgm_volume)
             SetBGMVolume(tonumber(Config.bgm_volume)/100)
         end
     },
-	{x = 0, y = -0.2, label = ("< SFX VOLUME : %d%% >"):format(Config.sfx_volume),
+	{x = 0, y = -0.2, label = ("SFX VOLUME : < %d%% >"):format(Config.sfx_volume),
 		action_e = function(button)
 			Config.sfx_volume = tostring((tonumber(Config.sfx_volume) + 5) % 105)
 		end,
@@ -138,7 +138,7 @@ Title.settings = Menu.new("Menu", {
 			Config.sfx_volume = tostring(math.max(tonumber(Config.sfx_volume) - 5, 0))
 		end,
         update = function(button)
-			button.label = ("< SFX VOLUME : %d%% >"):format(Config.sfx_volume)
+			button.label = ("SFX VOLUME : < %d%% >"):format(Config.sfx_volume)
             SetSFXVolume(tonumber(Config.sfx_volume)/100)
         end
     },
@@ -152,7 +152,7 @@ Title.settings = Menu.new("Menu", {
 
 local keySettingsItems = {}
 local padSettingsItems = {
-	{x = 0, y = -0.4, label = ("< AXIS DEADZONE : %d%% >"):format(Config.pad_deadzone),
+	{x = 0, y = -0.4, label = ("AXIS DEADZONE : < %d%% >"):format(Config.pad_deadzone),
 		action_e = function(button)
 			Config.pad_deadzone = tostring((tonumber(Config.pad_deadzone) + 5) % 105)
 		end,
@@ -163,7 +163,7 @@ local padSettingsItems = {
 			Config.pad_deadzone = tostring(math.max(tonumber(Config.pad_deadzone) - 5, 0))
 		end,
         update = function(button)
-            button.label = ("< AXIS DEADZONE : %d%% >"):format(Config.pad_deadzone)
+            button.label = ("AXIS DEADZONE : < %d%% >"):format(Config.pad_deadzone)
         end
 	},
 }
@@ -188,119 +188,137 @@ Title.keyconf = Menu.new("Menu", keySettingsItems)
 Title.padconf = Menu.new("Menu", padSettingsItems)
 
 Title.graphics = Menu.new("Menu", {
-	{x = 0, y = -0.4,
-		label = ("MATRIX SWAY AMPLITUDE: <%s%s>"):format(("|"):rep(tonumber(Config.sway_amplitude)), ("."):rep(10 - tonumber(Config.sway_amplitude))),
+	{x = 0, y = -0.4, param = 0,
+		label = ("MATRIX SWAY AMPLITUDE: <%s>"):format(DrawBar(Config.sway_amplitude, 10)),
 		action_e = function(button)
-			Config.sway_amplitude = tostring((tonumber(Config.sway_amplitude) + 1) % 10)
+			Config.sway_amplitude = tostring((tonumber(Config.sway_amplitude) + 1) % 11)
 		end,
 		action_r = function(button)
-			Config.sway_amplitude = tostring(math.min(10, tonumber(Config.sway_amplitude) + 1))
+			button.param = 1
 		end,
 		action_l = function(button)
-			Config.sway_amplitude = tostring(math.max(0, tonumber(Config.sway_amplitude) - 1))
+			button.param = -1
 		end,
         update = function(button)
-            button.label = ("MATRIX SWAY AMPLITUDE: <%s%s>"):format(("|"):rep(Config.sway_amplitude), ("."):rep(10 - Config.sway_amplitude))
+			Config.sway_amplitude = tostring(Clamp(tonumber(Config.sway_amplitude) + button.param, 0, 10))
+			button.param = 0
+            button.label = ("MATRIX SWAY AMPLITUDE: <%s>"):format(DrawBar(Config.sway_amplitude, 10))
         end
 	},
+
 	{x = 0, y = -0.3,
-		label = ("MATRIX SWAY SPEED: <%s%s>"):format(("|"):rep(tonumber(Config.sway_speed)), ("."):rep(10 - tonumber(Config.sway_speed))),
+		label = ("MATRIX SWAY SPEED: <%s>"):format(DrawBar(Config.sway_speed, 10)),
 		action_e = function(button)
-			Config.sway_speed = tostring((tonumber(Config.sway_speed) % 10) + 1)
+			Config.sway_speed = tostring(Mod1(tonumber(Config.sway_speed) + 1, 10))
 		end,
 		action_r = function(button)
-			Config.sway_speed = tostring(math.min(10, tonumber(Config.sway_speed) + 1))
+			button.param = 1
 		end,
 		action_l = function(button)
-			Config.sway_speed = tostring(math.max(1, tonumber(Config.sway_speed) - 1))
+			button.param = -1
 		end,
         update = function(button)
-            button.label = ("MATRIX SWAY SPEED: <%s%s>"):format(("|"):rep(Config.sway_speed), ("."):rep(10 - Config.sway_speed))
+			Config.sway_speed = tostring(Clamp(tonumber(Config.sway_speed) + button.param, 1, 10))
+			button.param = 0
+            button.label = ("MATRIX SWAY SPEED: <%s>"):format(DrawBar(Config.sway_speed, 10))
         end
 	},
-	{x = 0, y = -0.2,
-		label = ("MATRIX SWAY BOUNCINESS: <%s%s>"):format(("|"):rep(tonumber(Config.sway_bounciness)), ("."):rep(10 - tonumber(Config.sway_bounciness))),
+
+	{x = 0, y = -0.2, param = 0, label = ("MATRIX SWAY BOUNCINESS: <%s>"):format(DrawBar(Config.sway_bounciness, 10)),
 		action_e = function(button)
-			Config.sway_bounciness = tostring((tonumber(Config.sway_bounciness) % 10) + 1)
+			Config.sway_bounciness = tostring(Mod1(tonumber(Config.sway_bounciness) + 1, 10))
 		end,
 		action_r = function(button)
-			Config.sway_bounciness = tostring(math.min(10, tonumber(Config.sway_bounciness) + 1))
+			button.param = 1
 		end,
 		action_l = function(button)
-			Config.sway_bounciness = tostring(math.max(1, tonumber(Config.sway_bounciness) - 1))
+			button.param = -1
 		end,
         update = function(button)
-            button.label = ("MATRIX SWAY BOUNCINESS: <%s%s>"):format(("|"):rep(Config.sway_bounciness), ("."):rep(10 - Config.sway_bounciness))
+			Config.sway_bounciness = tostring(Clamp(tonumber(Config.sway_bounciness) + button.param, 1, 10))
+			button.param = 0
+            button.label = ("MATRIX SWAY BOUNCINESS: <%s>"):format(DrawBar(Config.sway_bounciness, 10))
         end
 	},
-	{x = 0, y =  0.1, label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg),
+
+	{x = 0, y =  0.1, label = ("DYNAMIC BACKGROUNDS : < %s >"):format(Config.dynamic_bg),
         update = function(button)
             Config.dynamic_bg = (Config.dynamic_bg == "O" and "X" or "O")
-            button.label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg)
+            button.label = ("DYNAMIC BACKGROUNDS : < %s >"):format(Config.dynamic_bg)
             if Config.dynamic_bg == "X" then PrerenderBG() end
         end
     },
-	{x = 0, y =  0.2, label = ("< BACKGROUND BRIGHTNESS : %d%% >"):format(Config.bg_brightness),
+
+	{x = 0, y =  0.2, param = 0, label = ("BACKGROUND BRIGHTNESS : < %d%% >"):format(Config.bg_brightness),
 		action_e = function(button)
 			Config.bg_brightness = tostring((tonumber(Config.bg_brightness) + 5) % 105)
 		end,
 		action_r = function(button)
-			Config.bg_brightness = tostring(math.min(tonumber(Config.bg_brightness) + 5, 100))
+			button.param = 1
 		end,
 		action_l = function(button)
-			Config.bg_brightness = tostring(math.max(tonumber(Config.bg_brightness) - 5, 0))
+			button.param = -1
 		end,
         update = function(button)
-            button.label = ("< BACKGROUND BRIGHTNESS : %d%% >"):format(Config.bg_brightness)
+			Config.bg_brightness = tostring(Clamp(tonumber(Config.bg_brightness) + 5 * button.param, 0, 100))
+			button.param = 0
+            button.label = ("BACKGROUND BRIGHTNESS : < %d%% >"):format(Config.bg_brightness)
         end
     },
-	{x = 0, y =  0.3, label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(tonumber(Config.blur_spread)), ("."):rep(10 - tonumber(Config.blur_spread))),
+
+	{x = 0, y =  0.3, param = 0, label = ("BLUR SPREAD: <%s>"):format(DrawBar(Config.blur_spread, 10)),
 		action_e = function(button)
-			Config.blur_spread = tostring((tonumber(Config.blur_spread) % 10))
+			Config.blur_spread = tostring((tonumber(Config.blur_spread) + 1) % 11)
 		end,
 		action_r = function(button)
-			Config.blur_spread = tostring(math.min(10, tonumber(Config.blur_spread) + 1))
+			button.param = 1
 		end,
 		action_l = function(button)
-			Config.blur_spread = tostring(math.max(0, tonumber(Config.blur_spread) - 1))
+			button.param = -1
 		end,
         update = function(button)
-            button.label = ("BLUR SPREAD: <%s%s>"):format(("|"):rep(Config.blur_spread), ("."):rep(10 - Config.blur_spread))
+            Config.blur_spread = tostring(Clamp(tonumber(Config.blur_spread) + button.param, 0, 10))
+			button.param = 0
+			button.label = ("BLUR SPREAD: <%s>"):format(DrawBar(Config.blur_spread, 10))
         end
 	},
-	{x = 0, y =  0.4, label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(tonumber(Config.trail_duration)), ("."):rep(10 - tonumber(Config.trail_duration))),
+
+	{x = 0, y =  0.4, label = ("TRAIL FADEOUT DURATION: <%s>"):format(DrawBar(Config.trail_duration, 10)),
 		action_e = function(button)
-			Config.trail_duration = tostring((tonumber(Config.trail_duration) % 10))
+			Config.trail_duration = tostring(Mod1(tonumber(Config.trail_duration)+1, 10))
 		end,
 		action_r = function(button)
-			Config.trail_duration = tostring(math.min(10, tonumber(Config.trail_duration) + 1))
+			button.param = 1
 		end,
 		action_l = function(button)
-			Config.trail_duration = tostring(math.max(0, tonumber(Config.trail_duration) - 1))
+			button.param = -1
 		end,
         update = function(button)
-            button.label = ("TRAIL FADEOUT DURATION: <%s%s>"):format(("|"):rep(Config.trail_duration), ("."):rep(10 - Config.trail_duration))
+			Config.trail_duration = tostring(Clamp(tonumber(Config.trail_duration) + button.param, 0, 10))
+			button.param = 0
+            button.label = ("TRAIL FADEOUT DURATION: <%s>"):format(DrawBar(Config.trail_duration, 10))
         end
 	},
+
 	{x = 0, y =  0.7, label = "BACK", action_e = change("settings")},
 })
 
 Title.window = Menu.new("Menu", {
-	{x = 0, y =  -0.3, param = 1, prev_screen = 1, label = ("< SCREEN : %s >"):format(1),
+	{x = 0, y =  -0.3, param = 1, prev_screen = 1, label = ("SCREEN : < %s >"):format(1),
 		action_e = function(button)
             button.prev_screen = button.param
-			button.param = (button.param % #FullScreenModes) + 1
+			button.param = Mod1(button.param + 1, #FullScreenModes)
 		end,
 		action_r = function(button)
 			button.prev_screen = button.param
-            button.param = (button.param % #FullScreenModes) + 1
+            button.param = Mod1(button.param + 1, #FullScreenModes)
 		end,
 		action_l = function(button)
 			button.prev_screen = button.param
-            button.param = ((button.param - 2) % #FullScreenModes) + 1
+            button.param = Mod1(button.param - 1, #FullScreenModes)
 		end,
         update = function(button)
-            button.label = ("< SCREEN : %s >"):format(button.param)
+            button.label = ("SCREEN : < %s >"):format(button.param)
 
 			local prev_resolution_id = button.parent.items[2].param
             local prev_resolutions   = FullScreenModes[button.prev_screen]
@@ -326,38 +344,37 @@ Title.window = Menu.new("Menu", {
         end
     },
 
-	{x = 0, y = -0.2, param = 1, label = ("< RESOLUTION : %4dx%4d >"):format("640", "480"),
+	{x = 0, y = -0.2, param = 1, label = ("RESOLUTION : < %4dx%4d >"):format("640", "480"),
 		action_e = function(button)
 			local cur_screen = button.parent.items[1].param
-			button.param = (button.param % #FullScreenModes[cur_screen]) + 1
+			button.param = Mod1(button.param + 1, #FullScreenModes[cur_screen])
 		end,
 		action_r = function(button)
 			local cur_screen = button.parent.items[1].param
-			button.param = (button.param % #FullScreenModes[cur_screen]) + 1
+			button.param = Mod1(button.param + 1, #FullScreenModes[cur_screen])
 		end,
 		action_l = function(button)
 			local cur_screen = button.parent.items[1].param
-			button.param = ((button.param - 2) % #FullScreenModes[cur_screen]) + 1
+			button.param = Mod1(button.param - 1, #FullScreenModes[cur_screen])
 		end,
 		update = function(button)
 			local cur_screen = button.parent.items[1].param
 			local mode = FullScreenModes[cur_screen][button.param]
-			--button.label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(mode.width, mode.height, cur_screen) -- Debuge
-			button.label = ("< RESOLUTION : %4dx%4d >"):format(mode.width, mode.height)
+			button.label = ("RESOLUTION : < %4dx%4d >"):format(mode.width, mode.height)
 		end
     },
 
-	{x = 0, y = 0.1, param = Config.fullscreen, label = ("< FULLSCREEN : %s >"):format(Config.fullscreen),
+	{x = 0, y = 0.1, param = Config.fullscreen, label = ("FULLSCREEN : < %s >"):format(Config.fullscreen),
         update = function(button)
             button.param = (button.param == "O" and "X" or "O")
-            button.label = ("< FULLSCREEN : %s >"):format(button.param)
+            button.label = ("FULLSCREEN : < %s >"):format(button.param)
         end
     },
 
-	{x = 0, y = 0.2, param = Config.vsync, label = ("< VSYNC : %s >"):format(Config.vsync),
+	{x = 0, y = 0.2, param = Config.vsync, label = ("VSYNC : < %s >"):format(Config.vsync),
         update = function(button)
             button.param = (button.param == "O" and "X" or "O")
-            button.label = ("< VSYNC : %s >"):format(button.param)
+            button.label = ("VSYNC : < %s >"):format(button.param)
         end
     },
 	
@@ -383,66 +400,75 @@ Title.window = Menu.new("Menu", {
 })
 
 
-
+-- [[ === === === [ HIGHSCORES ] === === === ]] --
 -- sets the default high score mode view to the first mode alphabetically
-local hs_keys = {}
+--TODO: Proper Sorting
+--TODO: Unlocking Secret Modes
+local modeList = {}
 local mode_indices = {} -- to prevent unnecessary lookups
 for k, _ in pairs(HighScores) do
-	if(k ~= "Death") then table.insert(hs_keys,k) end -- death is technically a secret mode
-	for i=1,#Levels do
+	if k ~= "Death" then table.insert(modeList, k) end -- death is technically a secret mode
+    for i=1,#Levels do
 		if(Levels[i].name == k) then mode_indices[k] = i end
 	end
 end
-table.sort(hs_keys) -- alphabetical order
-if(#hs_keys == 0) then
+if #modeList == 0 then
 	error("No high score keys. Are you sure there's at least one mode?")
+else
+    table.sort(modeList) -- alphabetical order
 end
 
 Title.highscores = Menu.new("Menu", {
-	{x = 0, y = -0.8, label = "< MODE: "..hs_keys[1].." >",
-		action_l = function(button)
-			Title.highscores.selection = (Title.highscores.selection+#Title.highscores.modeList-2)%(#Title.highscores.modeList)+1
-			button.label = "< MODE: "..hs_keys[Title.highscores.selection].." >"
-		end,
+	{x = 0, y = -0.8, param = 0, label = ("MODE: < %s >"):format(modeList[1]),
 		action_r = function(button)
-			Title.highscores.selection = (Title.highscores.selection)%(#Title.highscores.modeList)+1
-			button.label = "< MODE: "..hs_keys[Title.highscores.selection].." >"
-		end},
-	{x = 0, y = -0.7, label = "< SHOW CLEAR STATISTICS: X >",
-		action_l = function(button)
-			Title.highscores.showclear = not Title.highscores.showclear
-			button.label = "< SHOW CLEAR STATISTICS: " .. (Title.highscores.showclear and "O" or "X") .. " >"
+			button.param = 1
 		end,
-		action_r = function(button)
-			Title.highscores.showclear = not Title.highscores.showclear
-			button.label = "< SHOW CLEAR STATISTICS: " .. (Title.highscores.showclear and "O" or "X") .. " >"
-		end},
-	{x = 0, y =  0.7, label = "BACK", action_e = function(button)
-		Title.highscores.resetCounter = 0
-		Title.highscores.items[4].label = "RESET HIGH SCORES"
-		change("main")(button)
-	end},
-	{x = 0, y =  0.8, label = "RESET HIGH SCORES", action_e = function(button)
-		Title.highscores.resetCounter = Title.highscores.resetCounter + 1
-		if(Title.highscores.resetCounter == 1) then
-			button.label = "ARE YOU SURE YOU WANT TO CLEAR RECORDS?"
-		elseif(Title.highscores.resetCounter == 2) then
-			button.label = "ARE YOU REALLY SURE?"
-		elseif(Title.highscores.resetCounter == 3) then
-			button.label = "LAST CHANCE! ARE YOU SURE YOU WANT TO?"
-		else
-			button.label = "RESET HIGH SCORES"
-			Title.highscores.resetCounter = 0
-			for _,mode in pairs(Levels) do
-				local name = mode.name
-				HighScores[name] = {}
-			end
-			SaveHighScores()
+		action_l = function(button)
+			button.param = -1
+		end,
+        update = function(button)
+            Title.highscores.selection = Mod1(Title.highscores.selection + button.param, #button.parent.modeList)
+            button.param = 0
+            button.label = ("MODE: < %s >"):format(Title.highscores.modeList[Title.highscores.selection])
+        end
+	},
+
+	{x = 0, y = -0.7, label = "SHOW CLEAR STATISTICS: < X >",
+		update = function(button)
+			button.parent.showclear = not button.parent.showclear
+			button.label = ("SHOW CLEAR STATISTICS: < %s >"):format(button.parent.showclear and "O" or "X")
 		end
-	end}
+	},
+
+	{x = 0, y =  0.7, label = "BACK",
+	 	action_e = function(button)
+			button.parent.resetCounter = 1
+			button.parent.items[4]:update()
+			change("main")(button)
+		end
+	},
+
+	{x = 0, y =  0.8, label = "RESET HIGH SCORES",
+        labels = {"RESET HIGH SCORES",
+                  "ARE YOU SURE YOU WANT TO CLEAR RECORDS?",
+                  "ARE YOU REALLY SURE?",
+                  "LAST CHANCE! ARE YOU SURE YOU WANT TO?"},
+	 	action_e = function(button)
+            button.parent.resetCounter = button.parent.resetCounter + 1
+        end,
+	 	update = function(button)
+			if button.parent.resetCounter > #button.labels then
+				button.parent.resetCounter = 1
+				for _, mode in pairs(Levels) do HighScores[mode.name] = {} end
+				SaveHighScores()
+			end
+            button.label = button.labels[button.parent.resetCounter]
+		end
+	}
 })
-Title.highscores.selection = 1
-Title.highscores.modeList = hs_keys
-Title.highscores.modeIndices = mode_indices
-Title.highscores.showclear = false
-Title.highscores.resetCounter = 0
+--TODO: Apply general styling to this
+Title.highscores.selection    = 1
+Title.highscores.modeList     = modeList
+Title.highscores.modeIndices  = mode_indices
+Title.highscores.showclear    = false
+Title.highscores.resetCounter = 1

--- a/title.lua
+++ b/title.lua
@@ -285,7 +285,7 @@ Title.graphics = Menu.new("Menu", {
 
 	{x = 0, y =  0.4, label = ("TRAIL FADEOUT DURATION: <%s>"):format(DrawBar(Config.trail_duration, 10)),
 		action_e = function(button)
-			Config.trail_duration = tostring(Mod1(tonumber(Config.trail_duration)+1, 10))
+			Config.trail_duration = tostring((tonumber(Config.trail_duration) + 1) % 11)
 		end,
 		action_r = function(button)
 			button.param = 1
@@ -404,22 +404,17 @@ Title.window = Menu.new("Menu", {
 -- sets the default high score mode view to the first mode alphabetically
 --TODO: Proper Sorting
 --TODO: Unlocking Secret Modes
-local modeList = {}
+local mode_list = {}
 local mode_indices = {} -- to prevent unnecessary lookups
 for k, _ in pairs(HighScores) do
-	if k ~= "Death" then table.insert(modeList, k) end -- death is technically a secret mode
-    for i=1,#Levels do
-		if(Levels[i].name == k) then mode_indices[k] = i end
+	if k ~= "Death" then table.insert(mode_list, k) end -- death is technically a secret mode
+    for i = 1, #Levels do
+		if Levels[i].name == k then mode_indices[k] = i end
 	end
-end
-if #modeList == 0 then
-	error("No high score keys. Are you sure there's at least one mode?")
-else
-    table.sort(modeList) -- alphabetical order
 end
 
 Title.highscores = Menu.new("Menu", {
-	{x = 0, y = -0.8, param = 0, label = ("MODE: < %s >"):format(modeList[1]),
+	{x = 0, y = -0.8, param = 0, label = ("MODE: < %s >"):format(mode_list[1]),
 		action_r = function(button)
 			button.param = 1
 		end,
@@ -427,22 +422,22 @@ Title.highscores = Menu.new("Menu", {
 			button.param = -1
 		end,
         update = function(button)
-            Title.highscores.selection = Mod1(Title.highscores.selection + button.param, #button.parent.modeList)
+            Title.highscores.selection = Mod1(Title.highscores.selection + button.param, #button.parent.mode_list)
             button.param = 0
-            button.label = ("MODE: < %s >"):format(Title.highscores.modeList[Title.highscores.selection])
+            button.label = ("MODE: < %s >"):format(Title.highscores.mode_list[Title.highscores.selection])
         end
 	},
 
 	{x = 0, y = -0.7, label = "SHOW CLEAR STATISTICS: < X >",
 		update = function(button)
-			button.parent.showclear = not button.parent.showclear
-			button.label = ("SHOW CLEAR STATISTICS: < %s >"):format(button.parent.showclear and "O" or "X")
+			button.parent.show_clear = not button.parent.show_clear
+			button.label = ("SHOW CLEAR STATISTICS: < %s >"):format(button.parent.show_clear and "O" or "X")
 		end
 	},
 
 	{x = 0, y =  0.7, label = "BACK",
 	 	action_e = function(button)
-			button.parent.resetCounter = 1
+			button.parent.reset_counter = 1
 			button.parent.items[4]:update()
 			change("main")(button)
 		end
@@ -454,21 +449,21 @@ Title.highscores = Menu.new("Menu", {
                   "ARE YOU REALLY SURE?",
                   "LAST CHANCE! ARE YOU SURE YOU WANT TO?"},
 	 	action_e = function(button)
-            button.parent.resetCounter = button.parent.resetCounter + 1
+            button.parent.reset_counter = button.parent.reset_counter + 1
         end,
 	 	update = function(button)
-			if button.parent.resetCounter > #button.labels then
-				button.parent.resetCounter = 1
+			if button.parent.reset_counter > #button.labels then
+				button.parent.reset_counter = 1
 				for _, mode in pairs(Levels) do HighScores[mode.name] = {} end
 				SaveHighScores()
 			end
-            button.label = button.labels[button.parent.resetCounter]
+            button.label = button.labels[button.parent.reset_counter]
 		end
 	}
 })
 --TODO: Apply general styling to this
-Title.highscores.selection    = 1
-Title.highscores.modeList     = modeList
-Title.highscores.modeIndices  = mode_indices
-Title.highscores.showclear    = false
-Title.highscores.resetCounter = 1
+Title.highscores.selection     = 1
+Title.highscores.mode_list     = mode_list
+Title.highscores.mode_indices  = mode_indices
+Title.highscores.show_clear    = false
+Title.highscores.reset_counter = 1

--- a/title.lua
+++ b/title.lua
@@ -261,26 +261,6 @@ Title.graphics = Menu.new("Menu", {
 			Config.sway_bounciness = tostring(n)
 		end,
 	},
-	-- {x = 0, y =  0.0, label = ("< FULLSCREEN : %s >"):format(Config.vsync),
-		-- action_e = function(button)
-			-- Config.vsync = (Config.vsync == "O" and "X" or "O")
-			-- button.label = ("< VSYNC : %s >"):format(Config.vsync)
-            -- love.window.setVSync(Config.vsync == "O")
-            -- SaveConfig()
-		-- end,
-		-- action_r = function(button)
-			-- Config.vsync = (Config.vsync == "O" and "X" or "O")
-			-- button.label = ("< VSYNC : %s >"):format(Config.vsync)
-            -- love.window.setVSync(Config.vsync == "O")
-            -- SaveConfig()
-		-- end,
-		-- action_l = function(button)
-			-- Config.vsync = (Config.vsync == "O" and "X" or "O")
-			-- button.label = ("< VSYNC : %s >"):format(Config.vsync)
-            -- love.window.setVSync(Config.vsync == "O")
-            -- SaveConfig()
-		-- end,
-    -- },
 	{x = 0, y =  0.1, label = ("< DYNAMIC BACKGROUNDS : %s >"):format(Config.dynamic_bg),
 		action_e = function(button)
 			Config.dynamic_bg = (Config.dynamic_bg == "O" and "X" or "O")
@@ -361,70 +341,94 @@ Title.graphics = Menu.new("Menu", {
 })
 
 Title.window = Menu.new("Menu", {
-	{x = 0, y = -0.2,
-	label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(FullScreenModes[1].width, FullScreenModes[1].height, FullScreenModes[1].display),
-	param = 1,
+	{x = 0, y =  -0.4, param = CurrentScreen, prev_screen = CurrentScreen,
 		action_e = function(button)
-			button.param = (button.param % #FullScreenModes) + 1
-			local mode = FullScreenModes[button.param]
-			button.label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(mode.width, mode.height, mode.display)
+            button.prev_screen = CurrentScreen
+			CurrentScreen = (CurrentScreen % #FullScreenModes) + 1
 		end,
 		action_r = function(button)
-			button.param = (button.param % #FullScreenModes) + 1
-			local mode = FullScreenModes[button.param]
-			button.label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(mode.width, mode.height, mode.display)
+			button.prev_screen = CurrentScreen
+            CurrentScreen = (CurrentScreen % #FullScreenModes) + 1
 		end,
 		action_l = function(button)
-			button.param = ((button.param - 2) % #FullScreenModes) + 1
-			local mode = FullScreenModes[button.param]
-			button.label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(mode.width, mode.height, mode.display)
+			button.prev_screen = CurrentScreen
+            CurrentScreen = ((CurrentScreen - 2) % #FullScreenModes) + 1
 		end,
+        update = function(button)
+            button.label = ("< SCREEN : %s >"):format(CurrentScreen)
+
+            local cur_res_param     = button.parent.items[button.index+1].param
+            local aprox_switch_res  = math.floor((cur_res_param/#FullScreenModes[button.prev_screen])*#FullScreenModes[CurrentScreen])
+            button.parent.items[button.index+1].param = math.clamp(aprox_switch_res, 1, #FullScreenModes[CurrentScreen])
+
+            button.parent:updateItem(button.index+1) -- Updates `RESOLUTION` item to match a selected screen's resolutions.
+        end
     },
-	{x = 0, y =  0.1, label = ("< FULLSCREEN : %s >"):format(Config.fullscreen), param = Config.fullscreen,
+
+	{x = 0, y = -0.2, param = 1,
 		action_e = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-			button.label = ("< FULLSCREEN : %s >"):format(button.param)
+			button.param = (button.param % #FullScreenModes[CurrentScreen]) + 1
 		end,
 		action_r = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-			button.label = ("< FULLSCREEN : %s >"):format(button.param)
+			button.param = (button.param % #FullScreenModes[CurrentScreen]) + 1
 		end,
 		action_l = function(button)
-			button.param = (button.param == "O" and "X" or "O")
-			button.label = ("< FULLSCREEN : %s >"):format(button.param)
+			button.param = ((button.param - 2) % #FullScreenModes[CurrentScreen]) + 1
 		end,
+		update = function(button)
+			local mode = FullScreenModes[CurrentScreen][button.param]
+			--button.label = ("< RESOLUTION : %4dx%4d >\n(SCREEN #%d)"):format(mode.width, mode.height, CurrentScreen) -- Debuge
+			button.label = ("< RESOLUTION : %4dx%4d >"):format(mode.width, mode.height)
+		end
     },
-	{x = 0, y =  0.2, label = ("< VSYNC : %s >"):format(Config.vsync), param = Config.vsync,
+
+	{x = 0, y = 0.1, param = Config.fullscreen,
 		action_e = function(button)
 			button.param = (button.param == "O" and "X" or "O")
-			button.label = ("< VSYNC : %s >"):format(button.param)
 		end,
 		action_r = function(button)
 			button.param = (button.param == "O" and "X" or "O")
-			button.label = ("< VSYNC : %s >"):format(button.param)
 		end,
 		action_l = function(button)
 			button.param = (button.param == "O" and "X" or "O")
-			button.label = ("< VSYNC : %s >"):format(button.param)
 		end,
+        update = function(button)
+            button.label = ("< FULLSCREEN : %s >"):format(button.param)
+        end
+    },
+
+	{x = 0, y = 0.2, param = Config.vsync,
+		action_e = function(button)
+			button.param = (button.param == "O" and "X" or "O")
+		end,
+		action_r = function(button)
+			button.param = (button.param == "O" and "X" or "O")
+		end,
+		action_l = function(button)
+			button.param = (button.param == "O" and "X" or "O")
+		end,
+        update = function(button)
+            button.label = ("< VSYNC : %s >"):format(button.param)
+        end
     },
 	
-	{x = 0, y =  0.5, label = "APPLY",
+	{x = 0, y = 0.5, label = "APPLY",
 		action_e = function(button)
-			local width, height, display, vsync, fs
-			local buttons = button.parent.items
-			local mode = FullScreenModes[buttons[1].param]
-			width, height, display = mode.width, mode.height, mode.display
-			fs    = buttons[2].param
-			vsync = buttons[3].param
-			SetDisplayMode(width, height, display, fs == "O", vsync == "O")
-			Config.window_width   = tostring(width  )
-			Config.window_height  = tostring(height )
-			Config.window_display = tostring(display)
-			Config.fullscreen = fs
-			Config.vsync      = vsync
+			local buttons   = button.parent.items
+			local mode      = FullScreenModes[CurrentScreen][buttons[2].param]
+
+			local width, height, display    = mode.width, mode.height, CurrentScreen
+			local fs, vsync                 = buttons[3].param, buttons[4].param
+
+            SetDisplayMode(width, height, display, fs == "O", vsync == "O")
+			Config.window_width     = tostring(width  )
+			Config.window_height    = tostring(height )
+			Config.window_display   = tostring(display)
+			Config.fullscreen       = fs
+			Config.vsync            = vsync
 		end
 	},
+
 	{x = 0, y =  0.7, label = "BACK",  action_e = change("settings")},
 })
 
@@ -433,7 +437,7 @@ Title.window = Menu.new("Menu", {
 -- sets the default high score mode view to the first mode alphabetically
 local hs_keys = {}
 local mode_indices = {} -- to prevent unnecessary lookups
-for k,v in pairs(HighScores) do
+for k, _ in pairs(HighScores) do
 	if(k ~= "Death") then table.insert(hs_keys,k) end -- death is technically a secret mode
 	for i=1,#Levels do
 		if(Levels[i].name == k) then mode_indices[k] = i end

--- a/title.lua
+++ b/title.lua
@@ -286,7 +286,7 @@ Title.graphics = Menu.new("Menu", {
 })
 
 Title.window = Menu.new("Menu", {
-	{x = 0, y =  -0.4, param = 1, prev_screen = 1, label = ("< SCREEN : %s >"):format(1),
+	{x = 0, y =  -0.3, param = 1, prev_screen = 1, label = ("< SCREEN : %s >"):format(1),
 		action_e = function(button)
             button.prev_screen = button.param
 			button.param = (button.param % #FullScreenModes) + 1

--- a/util.lua
+++ b/util.lua
@@ -25,6 +25,11 @@ end
 
 function Mod1(x, base) return ((x - 1) % base) + 1 end
 
+function DrawBar(rep, size)
+	local _rep = tonumber(rep)
+	return ("%s%s"):format(("|"):rep(_rep), ("."):rep(size - _rep))
+end
+
 function Deepcopy(orig)
     local orig_type = type(orig)
     local copy

--- a/util.lua
+++ b/util.lua
@@ -18,10 +18,12 @@
 
 function NADA() end
 
-math.clamp = function(val, min, max)
+function Clamp(val, min, max)
     if min > max then min, max = max, min end
     return math.max(math.min(val, max), min)
 end
+
+function Mod1(x, base) return ((x - 1) % base) + 1 end
 
 function Deepcopy(orig)
     local orig_type = type(orig)
@@ -84,7 +86,7 @@ function CheckPadInput(pad, input)
 end
 
 function FormatTime(s)
-    local sec, cen, min = math.modf(math.max(0,s)), 0
+    local sec, cen, min = math.modf(math.max(0,s))
     sec, min = sec % 60, math.floor(sec/60)
     return string.format("%02d\'%02d\"%02d", min, sec, math.floor(cen*100))
 end
@@ -416,22 +418,25 @@ end
 
 -- Get all available screens and their supported resolutions.
 FullScreenModes = {}
-CurrentScreen = 1
 for i = 1, love.window.getDisplayCount() do
 	local modes = love.window.getFullscreenModes(i)
     local screen = {}
 	for _, mode in ipairs(modes) do
 		table.insert(screen, mode)
 	end
-    table.insert(FullScreenModes, screen)
-end
--- Sort the resolutions
-for _, screen in pairs(FullScreenModes) do
-    table.sort(screen, function(a, b)
-            if a.height ~= b.height then return a.height  < b.height
-        elseif a.width  ~= b.width  then return a.width   < b.width
+    table.sort(screen, function(a, b) -- Sort the resolutions
+            if a.height ~= b.height then return a.height < b.height
+        elseif a.width  ~= b.width  then return a.width  < b.width
         end
     end)
+    table.insert(FullScreenModes, screen)
+end
+
+for _, screen in pairs(FullScreenModes) do
+    for i, mode in pairs(screen) do
+        print(i, mode.width, mode.height)
+    end
+    --break
 end
 
 function SetDisplayMode(width, height, display, fs, vsync)

--- a/util.lua
+++ b/util.lua
@@ -432,12 +432,12 @@ for i = 1, love.window.getDisplayCount() do
     table.insert(FullScreenModes, screen)
 end
 
-for _, screen in pairs(FullScreenModes) do
-    for i, mode in pairs(screen) do
-        print(i, mode.width, mode.height)
-    end
-    --break
-end
+--for _, screen in pairs(FullScreenModes) do
+--    for i, mode in pairs(screen) do
+--        print(i, mode.width, mode.height)
+--    end
+--    --break
+--end
 
 function SetDisplayMode(width, height, display, fs, vsync)
 	love.window.updateMode(width, height, {display = display, fullscreen = fs, vsync = vsync, fullscreentype = "exclusive"})


### PR DESCRIPTION
Changed the way screens data is structured.
Changed the way the menu is updating items.

With this change I was able to make `Screen` option in `Window Options` as a separate item, upon change it updates the `Resolution` item and it selects the same or close enough resolution that was on the previously selected monitor(Need testing just in case).

Implemented skip upon pressing `Enter` for `splash screen`.

Adapted the menu thingies to what I've made, so there is less code and it's more maintainable.

Added `Mod1`(Cuz Oshi the Liller asked me to) and `Clamp` function.

Did a minor refactoring and removed unused PJT remains in the `Menu` logic (hope it's not too bad for you >w>;;).